### PR TITLE
Update package versions to see if it fixes the Node V5 CI issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,25 +27,26 @@
     "slt-globalize": "./bin/slt-globalize.js"
   },
   "dependencies": {
-    "async": "^1.4.2",
-    "cldr-data": "latest",
+    "async": "^1.5.2",
+    "cldr-data": "^28.0.3",
     "debug": "^2.2.0",
     "esprima": "^2.7.1",
     "estraverse": "^4.1.1",
-    "g11n-pipeline": "^1.1.3",
-    "globalize": "1.x",
+    "g11n-pipeline": "^1.1.4",
+    "globalize": "^1.1.0",
+    "htmlparser2": "^3.9.0",
     "md5": "^2.0.0",
     "mkdirp": "^0.5.1",
     "optional": "^0.1.3",
     "os-locale": "^1.4.0",
-    "posix-getopt": "^1.1.0",
+    "posix-getopt": "^1.2.0",
     "word-count": "^0.2.1"
   },
   "devDependencies": {
-    "eslint": "^1.x",
-    "eslint-config-strongloop": "^1.x",
-    "jscs": "^1.13.0",
-    "nyc": "^3.0.0",
-    "tap": "^1.2.0"
+    "eslint": "^1.10.3",
+    "eslint-config-strongloop": "^1.0.0",
+    "jscs": "^2.8.0",
+    "nyc": "^5.3.0",
+    "tap": "^5.1.1"
   }
 }


### PR DESCRIPTION
CI of all the 5 globalized packages fail on CI with all the platforms Node.js V5 and succeed on the other platforms.
