### PR TITLE
Move mktmpdir to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "lodash": "^4.3.0",
     "md5": "^2.0.0",
     "mkdirp": "^0.5.1",
+    "mktmpdir": "^0.1.1",
     "optional": "^0.1.3",
     "os-locale": "^1.4.0",
     "posix-getopt": "^1.2.0",
@@ -58,7 +59,6 @@
     "eslint-config-strongloop": "^1.0.0",
     "intercept-stdout": "^0.1.2",
     "jscs": "^2.8.0",
-    "mktmpdir": "^0.1.1",
     "nyc": "^5.3.0",
     "shelljs": "^0.7.0",
     "tap": "^5.1.1"


### PR DESCRIPTION
This fixes the regression introduced by b6b1bdb which started to use mktmpdir in production code.