### PR TITLE
deps: add fake cldr-data

### DIFF
--- a/node_modules/cldr-data/package.json
+++ b/node_modules/cldr-data/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "cldr-data",
+  "version": "25.0.0"
+}

--- a/package.json
+++ b/package.json
@@ -62,5 +62,8 @@
     "nyc": "^5.3.0",
     "shelljs": "^0.7.0",
     "tap": "^5.1.1"
-  }
+  },
+  "bundledDependencies": [
+    "cldr-data"
+  ]
 }


### PR DESCRIPTION
This will suppress the peerDependencies warnings in npm 2 and 3 while
avoiding the installation of cldr-data under npm v1.

Alternative to #70 for solving the peerDependencies problem.