### PR TITLE
Improve performance (part 2)

### DIFF
--- a/lib/globalize.js
+++ b/lib/globalize.js
@@ -13,6 +13,7 @@ var helper = require('./helper');
 var osLocale = require('os-locale');
 var MapCache = require('lodash/_MapCache');
 var md5 = require('md5');
+var memoize = require('lodash/memoize');
 var pathUtil = require('path');
 var translate = require('./translate');
 var util = require('util');
@@ -117,9 +118,10 @@ function setDefaultLanguage(lang) {
  */
 function formatMessage(path, variables, lang) {
   assert(path);
-  var message = path;
-  if (helper.hashKeys(path)) path = md5(path);
   if (!global.STRONGLOOP_GLB) setDefaultLanguage();
+  var message = path;
+  if (helper.hashKeys(path))
+    path = global.STRONGLOOP_GLB.getHash(path);
   lang = lang || global.STRONGLOOP_GLB.DEFAULT_LANG;
   debug('~~~ lang = %s %s %j %s', lang, path, variables, __filename);
   var trailer = helper.getTrailerAfterDot(path);
@@ -382,6 +384,7 @@ function loadGlobalize(lang, enumerateNodeModules) {
       versionG: versionG,
       bundles: {},
       formatters: new MapCache(),
+      getHash: memoize(md5),
       load: Globalize.load,
       locale: Globalize.locale,
       loadMessages: Globalize.loadMessages,

--- a/lib/globalize.js
+++ b/lib/globalize.js
@@ -11,6 +11,7 @@ var debug = require('debug')('strong-globalize');
 var fs = require('fs');
 var helper = require('./helper');
 var osLocale = require('os-locale');
+var MapCache = require('lodash/_MapCache');
 var md5 = require('md5');
 var pathUtil = require('path');
 var translate = require('./translate');
@@ -128,7 +129,19 @@ function formatMessage(path, variables, lang) {
   }
   function formatMsgInline(lang) {
     var g = global.STRONGLOOP_GLB.bundles[lang];
-    return g.messageFormatter(path)(variables || {});
+    var allFormatters = global.STRONGLOOP_GLB.formatters;
+    var langFormatters;
+    if (allFormatters.has(lang)) {
+      langFormatters = allFormatters.get(lang);
+    } else {
+      langFormatters = new MapCache();
+      allFormatters.set(lang, langFormatters);
+    }
+    if (langFormatters.has(path))
+      return langFormatters.get(path)(variables || {});
+    var format = g.messageFormatter(path);
+    langFormatters.set(path, format);
+    return format(variables || {});
   }
   try {
     message = formatMsgInline(lang);
@@ -368,6 +381,7 @@ function loadGlobalize(lang, enumerateNodeModules) {
       versionSG: versionSG,
       versionG: versionG,
       bundles: {},
+      formatters: new MapCache(),
       load: Globalize.load,
       locale: Globalize.locale,
       loadMessages: Globalize.loadMessages,

--- a/lib/translate.js
+++ b/lib/translate.js
@@ -85,6 +85,12 @@ function loadMsgFromFile(lang, rootDir, enumerateNodeModules) {
       messages[lang] = jsonObj;
       global.STRONGLOOP_GLB.loadMessages(messages);
       helper.registerResTag(fileIdHash, fileName, lang, tagType);
+      if (global.STRONGLOOP_GLB.formatters.has(lang)) {
+        var formatters = global.STRONGLOOP_GLB.formatters.get(lang);
+        for (var key in jsonObj) {
+          formatters.delete(key);
+        }
+      }
     });
 }
 

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "g11n-pipeline": "^1.2.2",
     "globalize": "^1.1.0",
     "htmlparser2": "^3.9.0",
-    "lodash": "^4.3.0",
+    "lodash": "^4.15.0",
     "md5": "^2.0.0",
     "mkdirp": "^0.5.1",
     "mktmpdir": "^0.1.1",


### PR DESCRIPTION
Over the weekend, I have realised that the initial version of [format benchmark](https://github.com/strongloop/strong-globalize/blob/0b553dbbab4f931d6561c29ca63fadd97ec7beb4/benchmark/format.js) was measuring a wrong scenario. Instead of measuring how long it takes to serve a translated string from `message/{lang}/messages.js`, we were measuring how long it takes to translate a string that's not included in the messages. The first commit fixes that by adding another run to the benchmark file.

The second commit improves the performance by re-using message formatters created by `globalize` module, which is the recommended approach per https://www.npmjs.com/package/globalize#performance

In the last commit, I am adding a cache of `md5` hashes to avoid potentially slow computation.

I believe all of these changes are fully backwards compatible and should not break any existing applications.

The only downside I am aware of is that these two caches are slightly increasing memory usage. If this becomes ever a problem, we can limit the cache size by using e.g. [lru-cache](https://www.npmjs.com/package/lru-cache).

Connect to #66 

@Setogit please review
cc @rmg @sam-github 

Benchmark results - before:

```
$ node benchmark/format.js
BASELINE
  1940 calls of "util.format()" took 3.179012 milliseconds
CASE 1 - no messages are loaded
  1940 calls of "g.f()" took 818.321937 milliseconds
  g.f() is 258x slower than util.format
CASE 2 - all messages are loaded
  1940 calls of "g.f()" took 2197.188276 milliseconds
  g.f() is 692x slower than util.format
```

After:

```
BASELINE
  1940 calls of "util.format()" took 3.591508ms
CASE 1 - no messages are loaded
  1940 calls of "g.f()" took 695.200518ms
  g.f() is 194x slower than util.format
CASE 2 - all messages are loaded
  1940 calls of "g.f()" took 1114.674444ms
  g.f() is 311x slower than util.format```
```

The exact ratio differs across runs, probably depending on CPU state, etc. The consistent part is that CASE 2 completes in about 1 second now, while it took over 2 seconds before.
