### PR TITLE
Detect strong-globalize in a shared module

### DIFF
--- a/lib/extract.js
+++ b/lib/extract.js
@@ -215,18 +215,31 @@ function extractMessages(blackList, deep, suppressOutput, callback) {
       _.concat(blackList, defaultBlackList) : defaultBlackList;
     clonedTxtCount += helper.cloneEnglishTxtSyncDeep();
   }
-  scannedJsCount = 0;
-  skippedJsCount = 0;
+
+  var files = {};
   helper.enumerateFilesSync(helper.getRootDir(), blackList,
     'js', false, deep, function(content, fileName) {
-      scannedJsCount++;
-      var msgs = scanAst(content, fileName, verboseMode);
-      if (msgs === null || msgs === undefined) {
-        skippedJsCount++;
-        return;
-      }
-      addToMsgs(msgs, fileName);
+      // We need to call require.resolve in order to resolve any simlinks
+      var resolvedFileName = require.resolve(fileName);
+      files[resolvedFileName] = {
+        fileName: fileName,
+        content: content,
+        scanned: false,
+        skipped: false,
+        exportsGlb: undefined,
+      };
     });
+
+  _(files).keys().forEach(function(resolvedFileName) {
+    processSourceFile(resolvedFileName, files, verboseMode);
+  });
+
+  scannedJsCount = _(files).map(_.property('scanned')).map(Number).sum();
+  skippedJsCount = _(files).map(_.property('skipped')).map(Number).sum();
+  _(files).omitBy(_.property('skipped')).forEach(function(entry) {
+    addToMsgs(entry.messages, entry.fileName);
+  });
+
   scannedHtmlCount = 0;
   skippedHtmlCount = 0;
   if (!deep) helper.enumerateFilesSync(helper.getRootDir(), blackList,
@@ -353,6 +366,19 @@ function invertLocObj(locObj) {
   return inv;
 }
 
+function processSourceFile(resolvedFileName, files, verboseMode) {
+  var entry = files[resolvedFileName];
+  if (entry.scanned) return entry;
+  entry.scanned = true;
+  var msgs = scanAst(entry.content, entry.fileName, verboseMode, files);
+  if (msgs === null || msgs === undefined) {
+    entry.skipped = true;
+    return;
+  }
+  entry.messages = msgs;
+  return entry;
+}
+
 function scanHtml(content, fileName, verboseMode) {
   var msgs = [];
   var tn = [];
@@ -401,7 +427,7 @@ function scanHtml(content, fileName, verboseMode) {
   return msgs;
 }
 
-function scanAst(content, fileName, verboseMode) {
+function scanAst(content, fileName, verboseMode, fileEntries) {
   var shebangExpr = /^\s*#\!.*?(\r\n|\r|\n)/m;
   if (shebangExpr.test(content)) { // hide it.
     content = content.replace(/#\!/, '//');
@@ -421,6 +447,7 @@ function scanAst(content, fileName, verboseMode) {
   if (rootDir[rootDir.length - 1] !== path.sep) rootDir += path.sep;
   var baseName = fileName.replace(rootDir, '');
   var sg = [];
+  var glbs = [];
   est.traverse(ast, {
     enter: function enterNode(node, parent) {
       if (node.type === 'VariableDeclaration'
@@ -441,10 +468,31 @@ function scanAst(content, fileName, verboseMode) {
             if (callee.type === 'Identifier'
               && callee.name === 'require') {
               argsParent.arguments.forEach(function(arg, ix) {
-                if (arg.type === 'Literal'
-                  && arg.value === 'strong-globalize') {
-                  if (d.id && d.id.type && d.id.type === 'Identifier') {
-                    sg.push(d.id.name);
+                if (arg.type !== 'Literal') return;
+                if (!(d.id && d.id.type && d.id.type === 'Identifier')) return;
+
+                if (arg.value === 'strong-globalize') {
+                  // require('strong-globalize')
+                  sg.push(d.id.name);
+                  return;
+                }
+
+                if (/^\.\/|\.\./.test(arg.value) && fileEntries) {
+                  // require('./local-file')
+                  var currentDir = path.dirname(fileName);
+                  var localFile = path.resolve(currentDir, arg.value);
+                  try {
+                    // resolve e.g. "lib/globalize" to "lib/globalize.js"
+                    // also resolve any symlinks in the path
+                    localFile = require.resolve(localFile);
+                  } catch (err) {
+                    return;
+                  }
+                  if (!(localFile in fileEntries)) return;
+                  var entry = processSourceFile(localFile, fileEntries,
+                                verboseMode);
+                  if (entry.exportsGlb) {
+                    glbs.push(d.id.name);
                   }
                 }
               });
@@ -455,7 +503,7 @@ function scanAst(content, fileName, verboseMode) {
     },
   });
   sg = _.uniq(_.compact(sg));
-  var glbs = [];
+  var moduleExportsGlb = false;
   est.traverse(ast, {
     enter: function enterNode(node, parent) {
       if (node.type === 'VariableDeclaration' && node.kind === 'var') {
@@ -473,9 +521,30 @@ function scanAst(content, fileName, verboseMode) {
             }
           }
         });
+      } else if (node.type === 'ExpressionStatement') {
+        var operator = node.expression.operator;
+        var left = node.expression.left;
+        var right = node.expression.right;
+        if (operator === '=' &&
+            left.type === 'MemberExpression' &&
+            left.object.type === 'Identifier' &&
+            left.object.name === 'module' &&
+            left.property.type === 'Identifier' &&
+            left.property.name === 'exports') {
+          var callOrNew = right.type === 'CallExpression' ||
+            right.type === 'NewExpression';
+          moduleExportsGlb = callOrNew &&
+            right.callee && right.callee.type === 'Identifier' &&
+            sg.indexOf(right.callee.name) >= 0;
+        }
       }
     },
   });
+
+  if (fileEntries) {
+    fileEntries[require.resolve(fileName)].exportsGlb = moduleExportsGlb;
+  }
+
   glbs = sg.concat(glbs);
   var msgs = [];
 

--- a/test/fixtures/extract-shared-globalize/globalize.js
+++ b/test/fixtures/extract-shared-globalize/globalize.js
@@ -1,0 +1,3 @@
+var SG = require('strong-globalize');
+SG.SetRootDir(__dirname);
+module.exports = SG();

--- a/test/fixtures/extract-shared-globalize/index.js
+++ b/test/fixtures/extract-shared-globalize/index.js
@@ -1,0 +1,3 @@
+var g = require('./globalize');
+
+g.log('text from index.js');

--- a/test/fixtures/extract-shared-globalize/intl/en/messages.json
+++ b/test/fixtures/extract-shared-globalize/intl/en/messages.json
@@ -1,0 +1,3 @@
+{
+  "6f2fa16795a449a96be134182d347a26": "text from index.js"
+}

--- a/test/fixtures/extract-shared-globalize/package.json
+++ b/test/fixtures/extract-shared-globalize/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "gmain",
+  "version": "1.0.0",
+  "main": "index.js",
+  "dependencies": {
+    "strong-globalize": "^2.x"
+  }
+}

--- a/test/test-extract-shared-globalize.js
+++ b/test/test-extract-shared-globalize.js
@@ -1,0 +1,41 @@
+// Copyright IBM Corp. 2016. All Rights Reserved.
+// Node module: strong-globalize
+// This file is licensed under the Artistic License 2.0.
+// License text available at https://opensource.org/licenses/Artistic-2.0
+
+var extract = require('../lib/extract');
+var sltTH = require('./slt-test-helper');
+var test = require('tap').test;
+
+var targets = {
+  'extract-shared-globalize': {
+    out: [
+      '    extracted: text from index.js\n',
+      '\n--- root: \n' +
+      '--- max depth: unlimited\n' +
+      '--- cloned: 0 txt\n' +
+      '--- scanned: 2 js, 0 html \n' +
+      '--- skipped: 0 js, 0 html \n' +
+      '--- extracted: 1 msges, 4 words, 18 characters\n',
+    ],
+    err: [
+    ],
+  },
+};
+
+test('test extract from project using shared globalize module', function(t) {
+  sltTH.testHarness(t, targets, false,
+    function(name, unhook_intercept, checkResults) {
+      var blackList = null;
+      var deep = true;
+      var suppressOutput = false;
+      extract.extractMessages(blackList, deep, suppressOutput,
+        function(_err) {
+          unhook_intercept();
+          t.notOk(_err, 'extractMessages succeeds.');
+          checkResults();
+        });
+    }, function() {
+      t.end();
+    });
+});


### PR DESCRIPTION
In this pull request, I am extending the code detecting strong-globalize instances in the application code to support the use-case described in #87, which is

```js
// lib/globalize.js
var SG = require('strong-globalize');
SG.SetRootDir(path.join(__dirname, '..'), { autonomousMsgLoading: 'all' });
module.exports = SG();

// lib/loopback.js
var g = require('./globalize');

// lib/registry.js
var g = require('./globalize');

// etc.
```

Connect to strongloop-internal/scrum-loopback#1044
See also #87 

@Setogit please take a look 

cc @0candy 
