### PR TITLE
Remove Unicode BOM

### DIFF
--- a/lib/extract.js
+++ b/lib/extract.js
@@ -269,7 +269,8 @@ function extractMessages(blackList, deep, suppressOutput, callback) {
     messagesJsonExists = messagesJsonExists || isMessagesJson;
     var msgFilePath = path.join(enLangDirPath, msgFile);
     try {
-      var jsonObj = JSON.parse(fs.readFileSync(msgFilePath));
+      var jsonObj = JSON.parse(
+        helper.stripBom(fs.readFileSync(msgFilePath, 'utf-8')));
       keys = Object.keys(jsonObj);
     } catch (e) {
       debug('*** JSON read or parse failure:', msgFile, e);
@@ -281,7 +282,8 @@ function extractMessages(blackList, deep, suppressOutput, callback) {
     var msgLocFilePath = path.join(pseudoLangDirPath, msgFile);
     var jsonLocObj = null;
     try {
-      jsonLocObj = JSON.parse(fs.readFileSync(msgLocFilePath));
+      jsonLocObj = JSON.parse(
+        helper.stringBom(fs.readFileSync(msgLocFilePath, 'utf-8')));
     } catch (e) {}
     if (jsonLocObj) {
       keys = Object.keys(jsonLocObj);

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -45,6 +45,7 @@ exports.resTagExists = resTagExists;
 exports.scanJson = scanJson;
 exports.setRootDir = setRootDir;
 exports.sortMsges = sortMsges;
+exports.stripBom = stripBom;
 exports.validateAmlValue = validateAmlValue;
 Object.defineProperty(exports, 'ENGLISH', {
   enumerable: false,
@@ -240,6 +241,10 @@ function resTagExists(fileIdHash, fileName, lang, tagType) {
   return exists;
 }
 
+function stripBom(str) {
+  return str.charCodeAt(0) === 0xFEFF ? str.slice(1) : str;
+}
+
 /**
  * Enumerate all JS files in this application
  * @param {Function}
@@ -311,7 +316,7 @@ function enumerateFilesSyncPriv(
     } else {
       var fileType = getTrailerAfterDot(item);
       if (targetFileType.indexOf(fileType) < 0) return;
-      var content = fs.readFileSync(child, 'utf8');
+      var content = stripBom(fs.readFileSync(child, 'utf8'));
       if (verbose) console.log('~~~ examining file:', child);
       if (checkNodeModules) {
         enumeratedFilesCount++;
@@ -529,9 +534,10 @@ function readToJson(langDirPath, msgFile, lang) {
   var jsonObj = null;
   var sourceFilePath = path.join(langDirPath, msgFile);
   if (fileType === 'json') {
-    jsonObj = JSON.parse(fs.readFileSync(sourceFilePath));
+    jsonObj = JSON.parse(
+      stripBom(fs.readFileSync(sourceFilePath, 'utf-8')));
   } else { // txt
-    var origStr = fs.readFileSync(sourceFilePath, 'utf8');
+    var origStr = stripBom(fs.readFileSync(sourceFilePath, 'utf8'));
     jsonObj = {};
     var re = /^([0-9a-f]{32})_(.*)\.txt/;
     var results = re.exec(msgFile);

--- a/test/fixtures/extract000/node_modules/gsub/intl/en/gsub.txt
+++ b/test/fixtures/extract000/node_modules/gsub/intl/en/gsub.txt
@@ -1,1 +1,1 @@
-This is a help text.
+﻿This is a help text.

--- a/test/fixtures/lint000/intl/en/messages000.json
+++ b/test/fixtures/lint000/intl/en/messages000.json
@@ -1,3 +1,0 @@
-{
-  "msg000MalformedDoubleCurly": "Error}}: {url} or {port} is invalid."
-}

--- a/test/fixtures/lint000/intl/en/messagesWithBOM.json
+++ b/test/fixtures/lint000/intl/en/messagesWithBOM.json
@@ -1,0 +1,3 @@
+﻿{
+    "msg000MalformedDoubleCurly": "Error}}: {url} or {port} is invalid."
+}


### PR DESCRIPTION
If messages.json was create by an external tool on Windows, Unicode BOM
\uFEFF may be added, which chokes JSON.parse.