### PR TITLE
Blacklist strong-globalize in deep extraction

### DIFF
--- a/lib/extract.js
+++ b/lib/extract.js
@@ -210,7 +210,7 @@ function extractMessages(blackList, deep, suppressOutput, callback) {
   }
   var verboseMode = (!deep && helper.isRootPackage());
   if (deep) {
-    var defaultBlackList = [];
+    var defaultBlackList = ['strong-globalize'];
     blackList = blackList ?
       _.concat(blackList, defaultBlackList) : defaultBlackList;
     clonedTxtCount += helper.cloneEnglishTxtSyncDeep();


### PR DESCRIPTION
No need to extract literals from strong-globalize package included
in dependencies.
