### PR TITLE
Check that name passed to headerIncluded has indexOf function

### DIFF
--- a/lib/helper.js
+++ b/lib/helper.js
@@ -734,6 +734,8 @@ function getPackageItem(root, itemName) {
  */
 function headerIncluded(name, headersAllowed) {
   var matched = false;
+  if (typeof name.indexOf !== "function") return matched;
+  
   if (Array.isArray(headersAllowed)) {
     headersAllowed.forEach(function(header) {
       if (matched) return;

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -734,8 +734,8 @@ function getPackageItem(root, itemName) {
  */
 function headerIncluded(name, headersAllowed) {
   var matched = false;
-  if (typeof name.indexOf !== "function") return matched;
-  
+  if (typeof name.indexOf !== 'function') return matched;
+
   if (Array.isArray(headersAllowed)) {
     headersAllowed.forEach(function(header) {
       if (matched) return;


### PR DESCRIPTION
Sometimes this gets passed in as null and crashes the entire app.   Since there is no way to match if it's nil, the best thing to do in this case seems to be just returning false.