### PR TITLE
Fix rfc5424 loggers in browser

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -65,7 +65,7 @@ StrongGlobalize.prototype.owrite = function() {
 StrongGlobalize.prototype.write = StrongGlobalize.prototype.owrite;
 
 function rfc5424(type, args, fn) {
-  return fn.apply(null, [type, ': '].concat(args));
+  return fn.apply(console, [type, ': '].concat(args));
 }
 // RFC 5424 Syslog Message Severities
 StrongGlobalize.prototype.emergency = function() {


### PR DESCRIPTION
Fix rfc5424() to correctly bind console.* methods to console object itself, because console methods require `this = console` in some older browsers.