### PR TITLE
Add advisory exception

### DIFF
--- a/.nsprc
+++ b/.nsprc
@@ -1,0 +1,3 @@
+{
+  "exceptions": ["https://nodesecurity.io/advisories/479"]
+}


### PR DESCRIPTION
Adding advisory exception till `superagent` fixes the issue. 
https://nodesecurity.io/advisories/479

See also https://github.com/strongloop/strong-globalize/issues/97