### PR TITLE
Upgrade deps to remove nsp warnings

### DIFF
--- a/.nsprc
+++ b/.nsprc
@@ -1,3 +1,0 @@
-{
-  "exceptions": ["https://nodesecurity.io/advisories/479"]
-}

--- a/package.json
+++ b/package.json
@@ -45,21 +45,21 @@
   },
   "dependencies": {
     "async": "^1.5.2",
-    "debug": "^2.2.0",
-    "esprima": "^3.1.3",
+    "debug": "^3.1.0",
+    "esprima": "^4.0.0",
     "estraverse": "^4.2.0",
-    "g11n-pipeline": "^1.4.0",
+    "g11n-pipeline": "^2.0.1",
     "htmlparser2": "^3.9.0",
     "lodash": "^4.15.0",
     "md5": "^2.0.0",
     "mkdirp": "^0.5.1",
     "mktmpdir": "^0.1.1",
     "optional": "^0.1.3",
-    "os-locale": "^1.4.0",
+    "os-locale": "^2.1.0",
     "posix-getopt": "^1.2.0",
     "word-count": "^0.2.1",
     "xtend": "^4.0.1",
-    "yamljs": "^0.2.8"
+    "yamljs": "^0.3.0"
   },
   "devDependencies": {
     "coveralls": "^2.11.9",


### PR DESCRIPTION
It turns out `.nsprc` is not transitive. This PR upgrades the deps to remove the offending dep.