### PR TITLE
Add Accept-Language negotiation

### DIFF
--- a/lib/extract.js
+++ b/lib/extract.js
@@ -574,6 +574,29 @@ function scanAst(content, fileName, verboseMode, fileEntries) {
     return objName + '.' + propName;
   }
 
+  // identify expression in style: g.http.f
+  function nodeIsFnCall(node) {
+    return node.type === 'CallExpression' &&
+            node.callee.type === 'MemberExpression' &&
+            node.callee.object &&
+            node.callee.object.type === 'CallExpression' &&
+            node.callee.object.callee &&
+            node.callee.object.callee.type === 'MemberExpression' &&
+            node.callee.object.callee.object &&
+            node.callee.object.callee.object.type === 'Identifier' &&
+            node.callee.object.callee.property &&
+            node.callee.object.callee.property.type === 'Identifier';
+  }
+
+  // identify expression in style g.f
+  function nodeIsObjCall(node) {
+    return node.type === 'CallExpression'
+            && node.callee.type === 'MemberExpression'
+            && node.callee.object
+            && (node.callee.object.type === 'Identifier' ||
+                node.callee.object.type === 'MemberExpression');
+  }
+
   function handleSGCall(node, objName, propName, args) {
     var ix = glbs.indexOf(objName);
 
@@ -607,12 +630,12 @@ function scanAst(content, fileName, verboseMode, fileEntries) {
 
   est.traverse(ast, {
     enter: function enterNode(node, parent) {
-      if (node.type === 'CallExpression'
-        && node.callee.type === 'MemberExpression'
-        && node.callee.object
-        && (node.callee.object.type === 'Identifier' ||
-          node.callee.object.type === 'MemberExpression')) {
-        handleSGCall(node, node.callee.object.name, node.callee.property.name);
+      if (nodeIsObjCall(node)) {
+        handleSGCall(node, node.callee.object.name,
+          node.callee.property.name, node.arguments);
+      } else if (nodeIsFnCall(node)) {
+        handleSGCall(node, node.callee.object.callee.object.name,
+          node.callee.property.name, node.arguments);
       } else if (
         (node.type === 'CallExpression' || node.type === 'NewExpression')
           && node.callee.type === 'Identifier'

--- a/lib/extract.js
+++ b/lib/extract.js
@@ -574,6 +574,37 @@ function scanAst(content, fileName, verboseMode, fileEntries) {
     return objName + '.' + propName;
   }
 
+  function handleSGCall(node, objName, propName, args) {
+    var ix = glbs.indexOf(objName);
+
+    if (ix >= 0) {
+      if (GLB_FN.indexOf(propName) >= 0) {
+        var msg = binExpOrLit(args[0]);
+        if (!msg) {
+          console.log('*** Skipped non-literal argument of "%s" at %s',
+            glbs[ix] + '.' + propName,
+            fileName + (node.callee.loc ?
+              (':' + node.callee.loc.start.line.toString()) : ''));
+          return;
+        }
+
+        var secondArgValue = null;
+        if (args[1])
+          secondArgValue = binExpOrLit(args[1]);
+        var literalArg = {
+          callee: composeName(objName, propName),
+          msg: msg,
+          secondArg: secondArgValue,
+          loc: node.loc ?
+            baseName + ':' + node.loc.start.line.toString() : '',
+        };
+        msgs.push(literalArg);
+      }
+    } else {
+      recordLiteralPosition(args[0], composeName(objName, propName));
+    }
+  }
+
   est.traverse(ast, {
     enter: function enterNode(node, parent) {
       if (node.type === 'CallExpression'
@@ -581,34 +612,7 @@ function scanAst(content, fileName, verboseMode, fileEntries) {
         && node.callee.object
         && (node.callee.object.type === 'Identifier' ||
           node.callee.object.type === 'MemberExpression')) {
-        var ix = glbs.indexOf(node.callee.object.name);
-        if (ix >= 0) {
-          if (GLB_FN.indexOf(node.callee.property.name) >= 0) {
-            var msg = binExpOrLit(node.arguments[0]);
-            if (!msg) {
-              console.log('*** Skipped non-literal argument of "%s" at %s',
-                glbs[ix] + '.' + node.callee.property.name,
-                fileName + (node.callee.loc ?
-                  (':' + node.callee.loc.start.line.toString()) : ''));
-              return;
-            }
-            var secondArgValue = null;
-            if (node.arguments[1])
-              secondArgValue = binExpOrLit(node.arguments[1]);
-            var literalArg = {
-              callee: composeName(node.callee.object.name,
-                node.callee.property.name),
-              msg: msg,
-              secondArg: secondArgValue,
-              loc: node.loc ?
-                baseName + ':' + node.loc.start.line.toString() : '',
-            };
-            msgs.push(literalArg);
-          }
-        } else {
-          recordLiteralPosition(node.arguments[0],
-            composeName(node.callee.object.name, node.callee.property.name));
-        }
+        handleSGCall(node, node.callee.object.name, node.callee.property.name);
       } else if (
         (node.type === 'CallExpression' || node.type === 'NewExpression')
           && node.callee.type === 'Identifier'

--- a/lib/globalize.js
+++ b/lib/globalize.js
@@ -19,6 +19,7 @@ var translate = require('./translate');
 var util = require('util');
 var YAML = require('yamljs');
 
+exports.setAppLanguages = setAppLanguages;
 exports.setDefaultLanguage = setDefaultLanguage;
 exports.setRootDir = helper.setRootDir;
 exports.setPersistentLogging = setPersistentLogging;
@@ -78,6 +79,35 @@ function setDefaultLanguage(lang) {
   global.STRONGLOOP_GLB.locale(lang);
   global.STRONGLOOP_GLB.DEFAULT_LANG = lang;
   return lang;
+}
+
+
+/**
+ * setAppLanguages
+ *
+ * @param {string} (optional, default: `[...]`) [].
+ *    Sets the supported languages for the application.
+ *    These should be a subset of the languages within the intl
+ *    directory.
+ *
+ *    If no argument is passed, the function uses the contents of
+ *    the intl directory to determine the application languages.
+ *
+ */
+function setAppLanguages(langs) {
+  langs = langs || readAppLanguagesSync() || [];
+  global.STRONGLOOP_GLB.APP_LANGS = langs;
+  return langs;
+}
+
+function readAppLanguagesSync() {
+  try {
+    var langs = fs.readdirSync(pathUtil.join(
+      global.STRONGLOOP_GLB.MASTER_ROOT_DIR, 'intl'));
+    return langs;
+  } catch (ex) {
+    return null;
+  }
 }
 
 /**
@@ -372,6 +402,7 @@ function loadGlobalize(lang, enumerateNodeModules) {
       locale: Globalize.locale,
       loadMessages: Globalize.loadMessages,
       DEFAULT_LANG: helper.ENGLISH,
+      APP_LANGS: readAppLanguagesSync(),
       LOG_FN: null,
       DISABLE_CONSOLE: false,
       MASTER_ROOT_DIR: helper.getRootDir(),

--- a/lib/helper.js
+++ b/lib/helper.js
@@ -11,6 +11,7 @@ var fs = require('fs');
 var md5 = require('md5');
 var mkdirp = require('mkdirp');
 var path = require('path');
+var acceptLanguage = require('accept-language');
 
 exports.cloneEnglishTxtSyncDeep = cloneEnglishTxtSyncDeep;
 exports.directoryDepth = directoryDepth;
@@ -46,6 +47,8 @@ exports.setRootDir = setRootDir;
 exports.sortMsges = sortMsges;
 exports.stripBom = stripBom;
 exports.validateAmlValue = validateAmlValue;
+exports.getLanguageFromRequest = getLanguageFromRequest;
+
 Object.defineProperty(exports, 'ENGLISH', {
   enumerable: false,
   configurable: false,
@@ -542,8 +545,11 @@ function readToJson(langDirPath, msgFile, lang) {
     jsonObj = {};
     var re = /^([0-9a-f]{32})_(.*)\.txt/;
     var results = re.exec(msgFile);
-    msgFile = (results && results.length === 3) ? // deep-extracted txt file ?
-    results[2] + '.txt' : msgFile;
+
+    if (results && results.length === 3) { // deep-extracted txt file ?
+      msgFile = results[2] + '.txt';
+    }
+
     jsonObj[msgFile] = mapPercent(JSON.parse(JSON.stringify(origStr)));
   }
   if (fileType === 'json' && HASH_KEYS && lang === exports.ENGLISH) {
@@ -674,7 +680,9 @@ function initIntlDirs() {
  */
 function isSupportedLanguage(lang) {
   if (!TARGET_LANGS) TARGET_LANGS = getSupportedLanguages();
-  return (TARGET_LANGS.indexOf(lang) >= 0);
+
+  return (TARGET_LANGS.indexOf(lang) >= 0) ||
+      (getAppLanguages().indexOf(lang) > 0);
 }
 
 /**
@@ -695,6 +703,13 @@ function getSupportedLanguages() {
       langs = _.concat(langs, theseLangs);
     });
   return _.uniq(langs);
+}
+
+function getAppLanguages() {
+  if (global.STRONGLOOP_GLB && global.STRONGLOOP_GLB.APP_LANGS) {
+    return global.STRONGLOOP_GLB.APP_LANGS;
+  }
+  return [];
 }
 
 /**
@@ -799,6 +814,31 @@ function repackArgs(args, initIx) {
     output.push(args[ix]);
   }
   return output;
+}
+
+
+/**
+ * Get the language (from the supported languages) that
+ * best matches the requested Accept-Language expression.
+ *
+ * @param req
+ * @param globalize
+ * @returns {*}
+ */
+
+function getLanguageFromRequest(req, appLanguages, defaultLanguage) {
+  if (!req || !req.headers) {
+    return defaultLanguage;
+  }
+
+  var reqLanguage = req.headers['accept-language'];
+  if (!reqLanguage) {
+    return defaultLanguage;
+  }
+
+  acceptLanguage.languages(appLanguages);
+  var bestLanguage = acceptLanguage.get(reqLanguage);
+  return bestLanguage;
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   },
   "dependencies": {
     "async": "^2.4.1",
+    "accept-language": "^3.0.18",
     "debug": "^3.1.0",
     "esprima": "^4.0.0",
     "estraverse": "^4.2.0",

--- a/test/fixtures/extract015/index.js
+++ b/test/fixtures/extract015/index.js
@@ -1,0 +1,14 @@
+var SG = require('strong-globalize');
+SG.SetRootDir(__dirname);
+var g = SG();
+var gsub = require('gsub');
+
+console.log(gsub.getHelpText());
+console.log(gsub.getHelpTextWithHashCode());
+var req = {
+  headers: {
+    'accept-language': 'en'
+  }
+};
+
+console.log(g.http(req).f('User name is %s.', gsub.getUserName()));

--- a/test/fixtures/extract015/intl/en/0a843e6d95df937ebc3f5cca3bf9a919_gsub2.txt
+++ b/test/fixtures/extract015/intl/en/0a843e6d95df937ebc3f5cca3bf9a919_gsub2.txt
@@ -1,0 +1,1 @@
+This is a hashed help text 2.

--- a/test/fixtures/extract015/intl/en/a5357f3f1d93bb2f4677a0e79dd6ce3d_gsub1.txt
+++ b/test/fixtures/extract015/intl/en/a5357f3f1d93bb2f4677a0e79dd6ce3d_gsub1.txt
@@ -1,0 +1,1 @@
+This is a hashed help text 1.

--- a/test/fixtures/extract015/intl/en/messages.json
+++ b/test/fixtures/extract015/intl/en/messages.json
@@ -1,0 +1,4 @@
+{
+  "8ea6d7223f10c5a95962c1269f5a5127": "User name is {0}.",
+  "msgPredefined": "This is a predefined message."
+}

--- a/test/fixtures/extract015/package.json
+++ b/test/fixtures/extract015/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "gmain",
+  "version": "1.0.0",
+  "main": "index.js",
+  "dependencies": {
+    "gsub": "^1.0.0"
+  }
+}

--- a/test/test-extract-2.js
+++ b/test/test-extract-2.js
@@ -101,6 +101,16 @@ var targets = {
     err: [
     ],
   },
+  extract015: {
+    out: [
+      '    extracted: User name is %s.\n',
+      '\n--- root: \n--- max depth: N/A\n--- cloned: N/A\n' +
+      '--- scanned: 1 js, 0 html \n--- skipped: 0 js, 0 html \n' +
+      '--- extracted: 1 msges, 4 words, 17 characters\n',
+    ],
+    err: [
+    ],
+  },
 };
 
 test('test extract misc testing', function(t) {

--- a/test/test-translate.js
+++ b/test/test-translate.js
@@ -40,6 +40,8 @@ test('language mapping for GPB', function(t) {
 
 SG.SetRootDir(__dirname);
 SG.SetDefaultLanguage();
+SG.SetAppLanguages();
+
 var g = SG();
 
 test('register resource tag', function(t) {
@@ -74,3 +76,16 @@ test('remove double curly braces', function(t) {
     'Remove double curly braces.');
   t.end();
 });
+
+test('accept-language header', function(t) {
+  var req = {
+    headers: {
+      'accept-language': 'en',
+    },
+  };
+  var message = g.http(req).f('Test message');
+  t.equal(message, 'Test message');
+  t.end();
+});
+
+


### PR DESCRIPTION
This is useful to integrate the library
with express apps.

Thie change makes it so that strong
globalize chooses the best matching language
based on the Accept-Language header of an
HTTP request.

This change also modifies the string extraction
logic so that it will look in the source code
for expressions like g.http(req).f(...)