### PR TITLE
chore: update dependencies & cleanup

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/.nsprc
+++ b/.nsprc
@@ -1,3 +1,0 @@
-{
-  "exceptions": ["https://nodesecurity.io/advisories/479"]
-}

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
     "globalize",
     "cldr"
   ],
+  "engines": {
+    "node": ">=4.0.0"
+  },
   "repository": {
     "type": "git",
     "url": "git://github.com/strongloop/strong-globalize.git"
@@ -45,19 +48,19 @@
   },
   "dependencies": {
     "accept-language": "^3.0.18",
-    "async": "^2.4.1",
+    "async": "^2.6.0",
     "debug": "^3.1.0",
     "esprima": "^4.0.0",
     "estraverse": "^4.2.0",
-    "g11n-pipeline": "^2.0.1",
+    "g11n-pipeline": "^3.0.0",
     "globalize": "^1.3.0",
     "htmlparser2": "^3.9.2",
-    "lodash": "^4.17.4",
+    "lodash": "^4.17.10",
     "md5": "^2.2.1",
     "mkdirp": "^0.5.1",
     "mktmpdir": "^0.1.1",
-    "optional": "^0.1.3",
-    "os-locale": "^2.0.0",
+    "optional": "^0.1.4",
+    "os-locale": "^2.1.0",
     "posix-getopt": "^1.2.0",
     "word-count": "^0.2.2",
     "xtend": "^4.0.1",
@@ -65,11 +68,11 @@
   },
   "devDependencies": {
     "coveralls": "^3.0.0",
-    "eslint": "^4.0.0",
+    "eslint": "^4.19.1",
     "eslint-config-strongloop": "^2.1.0",
     "intercept-stdout": "^0.1.2",
     "jscs": "^2.11.0",
-    "shelljs": "^0.7.8",
-    "tap": "^10.7.2"
+    "shelljs": "^0.8.1",
+    "tap": "^11.1.4"
   }
 }


### PR DESCRIPTION
- Update dependencies
- Drop Node 0.10 / 0.12
- Remove outdated `.nsprc` file as issue was fixed and we no longer need the exception
- Disable `package-lock.json` by adding `.npmrc`