### PR TITLE
Fix browser support

### DIFF
--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -18,7 +18,7 @@
   "license": "Artistic-2.0",
   "readmeFilename": "README.md",
   "main": "index.js",
-  "browser": "lib/browser.js",
+  "browser": "browser.js",
   "types": "lib/index.d.ts",
   "scripts": {
     "clean": "rimraf lib",


### PR DESCRIPTION
Fix runtime/package.json to use the top-level browser.js providing wrapper factory function instead of lib/browser.js which exports only ES6 class.

The bug was discovered by https://github.com/strongloop/strong-remoting/pull/446.

@raymondfeng please review. If the changes look good to you, then please go ahead with merging this patch and publishing a new version to npmjs.org. Thank you! 🙇 