### PR TITLE
Update`os-locale` to v3.0.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-- '6'
 - '8'
 - '10'
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -8,7 +8,7 @@
     "cldr"
   ],
   "engines": {
-    "node": ">=6"
+    "node": ">=8"
   },
   "repository": {
     "type": "git",

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -37,7 +37,7 @@
     "lodash": "^4.17.4",
     "md5": "^2.2.1",
     "mkdirp": "^0.5.1",
-    "os-locale": "^2.0.0",
+    "os-locale": "^3.0.1",
     "yamljs": "^0.3.0"
   },
   "devDependencies": {


### PR DESCRIPTION
We had updated `strong-globalize` in here https://github.com/strongloop/strong-soap/pull/189 because of `mem`.

So update`os-locale` to v3.0.1 which use a safe `mem` and release a patch version. 
Everything will be OK.

Thanks.
