### PR TITLE
Fix #142 Exception on executable built on zeit/pkg

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,5 +52,11 @@
     "tslint": "^5.14.0",
     "typescript": "^3.3.4000"
   },
-  "dependencies": {}
+  "dependencies": {},
+  "files": [
+    "cldr/",
+    "lib/",
+    "src/",
+    "benchmark/"
+  ]
 }


### PR DESCRIPTION
Fixes #142, "Files" Property should be included for use in zeit/pkg

### Description
PR to fix issue

#### Related issues
- connect to [strong-soap #215](https://github.com/strongloop/strong-soap/issues/215)