### PR TITLE
Feat add alias support for zh-cn and zh-tw

### DIFF
--- a/packages/runtime/src/globalize.ts
+++ b/packages/runtime/src/globalize.ts
@@ -12,6 +12,7 @@ import * as Globalize from 'globalize';
 import {parse} from 'yamljs';
 import {AnyObject, STRONGLOOP_GLB} from './config';
 import * as helper from './helper';
+import {getLangAlias} from './helper';
 const dbg = debugModule('strong-globalize');
 const osLocale = require('os-locale');
 const MapCache = require('lodash/_MapCache');
@@ -63,6 +64,7 @@ function osLanguage() {
  *     It tries to use OS language, then falls back to 'en'
  */
 export function setDefaultLanguage(lang?: string) {
+  if (lang) lang = getLangAlias(lang);
   lang = helper.isSupportedLanguage(lang) ? lang : undefined;
   lang = lang || MY_APP_LANG || OS_LANG || helper.ENGLISH;
   loadGlobalize(lang);
@@ -71,6 +73,7 @@ export function setDefaultLanguage(lang?: string) {
   }
   STRONGLOOP_GLB.locale!(lang);
   STRONGLOOP_GLB.DEFAULT_LANG = lang;
+
   return lang;
 }
 

--- a/packages/runtime/src/helper.ts
+++ b/packages/runtime/src/helper.ts
@@ -952,3 +952,20 @@ export function removeDoubleCurlyBraces(json: AnyObject) {
     debug(count, key + ' : ' + json[key]);
   });
 }
+
+/**
+ * If an language has alias name that SG supports, return the alias name.
+ *
+ * The known aliases are hard-coded to solve issue
+ * https://github.com/strongloop/strong-globalize/issues/150
+ * @param lang
+ */
+export function getLangAlias(lang: string): string {
+  // The {lang: alias} pairs
+  const ALIAS_MAP: {[lang: string]: string} = {
+    'zh-cn': 'zh-Hans',
+    'zh-tw': 'zh-Hant',
+  };
+  if (lang && ALIAS_MAP.hasOwnProperty(lang)) return ALIAS_MAP[lang];
+  return lang;
+}

--- a/packages/runtime/src/strong-globalize.ts
+++ b/packages/runtime/src/strong-globalize.ts
@@ -9,6 +9,7 @@ import * as helper from './helper';
 import * as path from 'path';
 
 import {AnyObject, STRONGLOOP_GLB} from './config';
+import {getLangAlias} from './helper';
 
 // tslint:disable:no-any
 
@@ -93,6 +94,7 @@ export class StrongGlobalize {
   }
 
   setLanguage(lang?: string) {
+    if (lang) lang = getLangAlias(lang);
     lang = helper.isSupportedLanguage(lang)
       ? lang
       : STRONGLOOP_GLB.DEFAULT_LANG;
@@ -352,11 +354,12 @@ export class StrongGlobalize {
     StrongGlobalize
   >(); /* eslint-env es6 */
   http(req: {headers: AnyObject}) {
-    const matchingLang = helper.getLanguageFromRequest(
+    let matchingLang = helper.getLanguageFromRequest(
       req,
       this._options.appLanguages,
       this._options.language
     );
+    matchingLang = getLangAlias(matchingLang);
 
     let sg = StrongGlobalize.sgCache.get(matchingLang);
     if (sg) {

--- a/packages/runtime/test/test-globalize-singleton.js
+++ b/packages/runtime/test/test-globalize-singleton.js
@@ -93,6 +93,18 @@ test('formatMessage', function(t) {
   targetMsg = 'Error：' + params.url + '或者' + params.port + '是無效。';
   t.equal(message, targetMsg, 'Traditional Chinese message formatting works.');
 
+  g.setDefaultLanguage('zh-cn');
+  message = g.formatMessage(key, params);
+  t.comment(message);
+  targetMsg = 'Error：' + params.url + '或者' + params.port + '是无效。';
+  t.equal(message, targetMsg, 'Simplified Chinese message formatting works.');
+
+  g.setDefaultLanguage('zh-tw');
+  message = g.formatMessage(key, params);
+  t.comment(message);
+  targetMsg = 'Error：' + params.url + '或者' + params.port + '是無效。';
+  t.equal(message, targetMsg, 'Traditional Chinese message formatting works.');
+
   g.setDefaultLanguage('de');
   message = g.formatMessage(key, params);
   t.comment(message);

--- a/packages/runtime/test/test-load-msg.js
+++ b/packages/runtime/test/test-load-msg.js
@@ -11,7 +11,7 @@ var test = require('tap').test;
 
 SG.SetRootDir(__dirname);
 SG.SetDefaultLanguage();
-SG.SetAppLanguages();
+SG.SetAppLanguages(['en', 'zh-cn', 'zh-Hans']);
 
 var g = new SG();
 
@@ -56,7 +56,7 @@ test('remove double curly braces', function(t) {
   t.end();
 });
 
-test('accept-language header', function(t) {
+test('accept-language header - en', function(t) {
   var req = {
     headers: {
       'accept-language': 'en',
@@ -64,5 +64,22 @@ test('accept-language header', function(t) {
   };
   var message = g.http(req).f('Test message');
   t.equal(message, 'Test message');
+  t.end();
+});
+
+test('accept-language header - alias', function(t) {
+  var req = {
+    headers: {
+      // alias to 'zh-Hans'
+      'accept-language': 'zh-cn',
+    },
+  };
+
+  // create a SG instance for language 'zh-Hans' and register it
+  var sg_hans = new SG({language: 'zh-Hans'});
+  SG.sgCache.set('zh-Hans', sg_hans);
+
+  var cachedSg = g.http(req);
+  t.equal(cachedSg.getLanguage(), 'zh-Hans');
   t.end();
 });


### PR DESCRIPTION
support feature in https://github.com/strongloop/strong-globalize/issues/150

If a request.header has accept-language of zh-cn or zh-tw, strong-globalize should equivocate that to zh-Hans and zh-Hant respectively. 

The change is applied to `http()`, `setLanguage()` and `setDefaultLanguage`.