### PR TITLE
chore: update package locks

### DIFF
--- a/packages/cli/package-lock.json
+++ b/packages/cli/package-lock.json
@@ -14,16 +14,15 @@
 			}
 		},
 		"@babel/generator": {
-			"version": "7.6.0",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.6.0.tgz",
-			"integrity": "sha512-Ms8Mo7YBdMMn1BYuNtKuP/z0TgEIhbcyB8HVR6PPNYp4P61lMsABiS4A3VG1qznjXVCf3r+fVHhm4efTYVsySA==",
+			"version": "7.7.7",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.7.7.tgz",
+			"integrity": "sha512-/AOIBpHh/JU1l0ZFS4kiRCBnLi6OTHzh0RPk3h9isBxkkqELtQNFi1Vr/tiG9p1yfoUdKVwISuXWQR+hwwM4VQ==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.6.0",
+				"@babel/types": "^7.7.4",
 				"jsesc": "^2.5.1",
 				"lodash": "^4.17.13",
-				"source-map": "^0.5.0",
-				"trim-right": "^1.0.1"
+				"source-map": "^0.5.0"
 			},
 			"dependencies": {
 				"source-map": {
@@ -35,32 +34,32 @@
 			}
 		},
 		"@babel/helper-function-name": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
-			"integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.7.4.tgz",
+			"integrity": "sha512-AnkGIdiBhEuiwdoMnKm7jfPfqItZhgRaZfMg1XX3bS25INOnLPjPG1Ppnajh8eqgt5kPJnfqrRHqFqmjKDZLzQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-get-function-arity": "^7.0.0",
-				"@babel/template": "^7.1.0",
-				"@babel/types": "^7.0.0"
+				"@babel/helper-get-function-arity": "^7.7.4",
+				"@babel/template": "^7.7.4",
+				"@babel/types": "^7.7.4"
 			}
 		},
 		"@babel/helper-get-function-arity": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
-			"integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.7.4.tgz",
+			"integrity": "sha512-QTGKEdCkjgzgfJ3bAyRwF4yyT3pg+vDgan8DSivq1eS0gwi+KGKE5x8kRcbeFTb/673mkO5SN1IZfmCfA5o+EA==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.0.0"
+				"@babel/types": "^7.7.4"
 			}
 		},
 		"@babel/helper-split-export-declaration": {
-			"version": "7.4.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
-			"integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.7.4.tgz",
+			"integrity": "sha512-guAg1SXFcVr04Guk9eq0S4/rWS++sbmyqosJzVs8+1fH5NI+ZcmkaSkc7dmtAFbHFva6yRJnjW3yAcGxjueDug==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.4.4"
+				"@babel/types": "^7.7.4"
 			}
 		},
 		"@babel/highlight": {
@@ -75,77 +74,61 @@
 			}
 		},
 		"@babel/parser": {
-			"version": "7.5.5",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.5.5.tgz",
-			"integrity": "sha512-E5BN68cqR7dhKan1SfqgPGhQ178bkVKpXTPEXnFJBrEt8/DKRZlybmy+IgYLTeN7tp1R5Ccmbm2rBk17sHYU3g==",
+			"version": "7.7.7",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.7.tgz",
+			"integrity": "sha512-WtTZMZAZLbeymhkd/sEaPD8IQyGAhmuTuvTzLiCFM7iXiVdY0gc0IaI+cW0fh1BnSMbJSzXX6/fHllgHKwHhXw==",
 			"dev": true
 		},
 		"@babel/runtime": {
-			"version": "7.6.0",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.6.0.tgz",
-			"integrity": "sha512-89eSBLJsxNxOERC0Op4vd+0Bqm6wRMqMbFtV3i0/fbaWw/mJ8Q3eBvgX0G4SyrOOLCtbu98HspF8o09MRT+KzQ==",
+			"version": "7.7.7",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.7.tgz",
+			"integrity": "sha512-uCnC2JEVAu8AKB5do1WRIsvrdJ0flYx/A/9f/6chdacnEZ7LmavjdsDXr5ksYBegxtuTPR5Va9/+13QF/kFkCA==",
 			"dev": true,
 			"requires": {
 				"regenerator-runtime": "^0.13.2"
 			}
 		},
 		"@babel/runtime-corejs2": {
-			"version": "7.6.0",
-			"resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.6.0.tgz",
-			"integrity": "sha512-zbPQzlbyJab2xCYb6VaESn8Tk/XiVpQJU7WvIKiQCwlFyc2NSCzKjqtBXCvpZBbiTOHCx10s2656REVnySwb+A==",
+			"version": "7.7.7",
+			"resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.7.7.tgz",
+			"integrity": "sha512-P91T3dFYQL7aj44PxOMIAbo66Ag3NbmXG9fseSYaXxapp3K9XTct5HU9IpTOm2D0AoktKusgqzN5YcSxZXEKBQ==",
 			"requires": {
 				"core-js": "^2.6.5",
 				"regenerator-runtime": "^0.13.2"
 			}
 		},
 		"@babel/template": {
-			"version": "7.6.0",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.6.0.tgz",
-			"integrity": "sha512-5AEH2EXD8euCk446b7edmgFdub/qfH1SN6Nii3+fyXP807QRx9Q73A2N5hNwRRslC2H9sNzaFhsPubkS4L8oNQ==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.4.tgz",
+			"integrity": "sha512-qUzihgVPguAzXCK7WXw8pqs6cEwi54s3E+HrejlkuWO6ivMKx9hZl3Y2fSXp9i5HgyWmj7RKP+ulaYnKM4yYxw==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.0.0",
-				"@babel/parser": "^7.6.0",
-				"@babel/types": "^7.6.0"
-			},
-			"dependencies": {
-				"@babel/parser": {
-					"version": "7.6.0",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.6.0.tgz",
-					"integrity": "sha512-+o2q111WEx4srBs7L9eJmcwi655eD8sXniLqMB93TBK9GrNzGrxDWSjiqz2hLU0Ha8MTXFIP0yd9fNdP+m43ZQ==",
-					"dev": true
-				}
+				"@babel/parser": "^7.7.4",
+				"@babel/types": "^7.7.4"
 			}
 		},
 		"@babel/traverse": {
-			"version": "7.6.0",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.6.0.tgz",
-			"integrity": "sha512-93t52SaOBgml/xY74lsmt7xOR4ufYvhb5c5qiM6lu4J/dWGMAfAh6eKw4PjLes6DI6nQgearoxnFJk60YchpvQ==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.7.4.tgz",
+			"integrity": "sha512-P1L58hQyupn8+ezVA2z5KBm4/Zr4lCC8dwKCMYzsa5jFMDMQAzaBNy9W5VjB+KAmBjb40U7a/H6ao+Xo+9saIw==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.5.5",
-				"@babel/generator": "^7.6.0",
-				"@babel/helper-function-name": "^7.1.0",
-				"@babel/helper-split-export-declaration": "^7.4.4",
-				"@babel/parser": "^7.6.0",
-				"@babel/types": "^7.6.0",
+				"@babel/generator": "^7.7.4",
+				"@babel/helper-function-name": "^7.7.4",
+				"@babel/helper-split-export-declaration": "^7.7.4",
+				"@babel/parser": "^7.7.4",
+				"@babel/types": "^7.7.4",
 				"debug": "^4.1.0",
 				"globals": "^11.1.0",
 				"lodash": "^4.17.13"
-			},
-			"dependencies": {
-				"@babel/parser": {
-					"version": "7.6.0",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.6.0.tgz",
-					"integrity": "sha512-+o2q111WEx4srBs7L9eJmcwi655eD8sXniLqMB93TBK9GrNzGrxDWSjiqz2hLU0Ha8MTXFIP0yd9fNdP+m43ZQ==",
-					"dev": true
-				}
 			}
 		},
 		"@babel/types": {
-			"version": "7.6.1",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.6.1.tgz",
-			"integrity": "sha512-X7gdiuaCmA0uRjCmRtYJNAVCc/q+5xSgsfKJHqMN4iNLILX39677fJE1O40arPMh0TTtS9ItH67yre6c7k6t0g==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.4.tgz",
+			"integrity": "sha512-cz5Ji23KCi4T+YIE/BolWosrJuSmoZeN1EFnRtBwF+KKLi8GG/Z2c2hOJJeCXPk4mwk4QFvTmwIodJowXgttRA==",
 			"dev": true,
 			"requires": {
 				"esutils": "^2.0.2",
@@ -176,9 +159,9 @@
 			}
 		},
 		"@types/async": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/@types/async/-/async-3.0.1.tgz",
-			"integrity": "sha512-fBq+1+btw/4CPGCpp3B05vUsslyikLUSUoZmFEjjHrUEPOisIVxUzGJFg1k43iWq9y0lC2UDqWAlg5ynUCwwSA==",
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/@types/async/-/async-3.0.3.tgz",
+			"integrity": "sha512-FrIcC67Zpko1jO8K4d30C41/KVhAABbMbaSxccvXacxPcKbDBav+8WoFzv72BA2zJvyX4T9PFz0we1hcNymgGA==",
 			"dev": true
 		},
 		"@types/debug": {
@@ -221,9 +204,9 @@
 			}
 		},
 		"@types/estree": {
-			"version": "0.0.39",
-			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
-			"integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
+			"version": "0.0.42",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.42.tgz",
+			"integrity": "sha512-K1DPVvnBCPxzD+G51/cxVIoc2X8uUVl1zpJeE6iKcgHMj4+tbat5Xu4TjV7v2QSDbIeAfLi2hIk+u2+s0MlpUQ==",
 			"dev": true
 		},
 		"@types/htmlparser2": {
@@ -238,9 +221,9 @@
 			}
 		},
 		"@types/lodash": {
-			"version": "4.14.138",
-			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.138.tgz",
-			"integrity": "sha512-A4uJgHz4hakwNBdHNPdxOTkYmXNgmUAKLbXZ7PKGslgeV0Mb8P3BlbYfPovExek1qnod4pDfRbxuzcVs3dlFLg==",
+			"version": "4.14.149",
+			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.149.tgz",
+			"integrity": "sha512-ijGqzZt/b7BfzcK9vTrS6MFljQRPn5BFWOx8oE0GYxribu6uV+aA9zZuXI1zc/etK9E8nrgdoF2+LgUw7+9tJQ==",
 			"dev": true
 		},
 		"@types/md5": {
@@ -262,9 +245,9 @@
 			}
 		},
 		"@types/node": {
-			"version": "12.7.5",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.5.tgz",
-			"integrity": "sha512-9fq4jZVhPNW8r+UYKnxF1e2HkDWOWKM5bC2/7c9wPV835I0aOrVbS/Hw/pWPk2uKrNXQqg9Z959Kz+IYDd5p3w==",
+			"version": "12.12.24",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.24.tgz",
+			"integrity": "sha512-1Ciqv9pqwVtW6FsIUKSZNB82E5Cu1I2bBTj1xuIHXLe/1zYLl3956Nbhg2MzSYHVfl9/rmanjbQIb7LibfCnug==",
 			"dev": true
 		},
 		"@types/optimist": {
@@ -307,9 +290,9 @@
 			}
 		},
 		"anymatch": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.0.tgz",
-			"integrity": "sha512-Ozz7l4ixzI7Oxj2+cw+p0tVUt27BpaJ+1+q1TCeANWxHpvyn2+Un+YamBdfKu0uh8xLodGhoa1v7595NhKDAuA==",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
+			"integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
 			"dev": true,
 			"requires": {
 				"normalize-path": "^3.0.0",
@@ -332,9 +315,9 @@
 			"dev": true
 		},
 		"arg": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/arg/-/arg-4.1.1.tgz",
-			"integrity": "sha512-SlmP3fEA88MBv0PypnXZ8ZfJhwmDeIE3SP71j37AiXQBXYosPV0x6uISAaHYSlSVhmHOVkomen0tbGk6Anlebw==",
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/arg/-/arg-4.1.2.tgz",
+			"integrity": "sha512-+ytCkGcBtHZ3V2r2Z06AncYO8jz46UEamcspGoU8lHcEbpn6J77QK0vdWvChsclg/tM5XIJC5tnjmPp7Eq6Obg==",
 			"dev": true
 		},
 		"argparse": {
@@ -366,9 +349,9 @@
 			"integrity": "sha512-4vx/aaY6j/j3Lw3fbCHNWP0pPaTCew3F6F3hYyl/tHs/ndmV1q7NW9T5yuJ2XAGwdQrP+6Wu20x06U4APo/iQQ=="
 		},
 		"async-hook-domain": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/async-hook-domain/-/async-hook-domain-1.1.0.tgz",
-			"integrity": "sha512-NH7V97d1yCbIanu2oDLyPT2GFNct0esPeJyRfkk8J5hTztHVSQp4UiNfL2O42sCA9XZPU8OgHvzOmt9ewBhVqA==",
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/async-hook-domain/-/async-hook-domain-1.1.3.tgz",
+			"integrity": "sha512-ZovMxSbADV3+biB7oR1GL5lGyptI24alp0LWHlmz1OFc5oL47pz3EiIF6nXOkDW7yLqih4NtsiYduzdDW0i+Wg==",
 			"dev": true,
 			"requires": {
 				"source-map-support": "^0.5.11"
@@ -387,9 +370,9 @@
 			"dev": true
 		},
 		"aws4": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
-			"integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.0.tgz",
+			"integrity": "sha512-Uvq6hVe90D0B2WEnUqtdgY1bATGz3mw33nH9Y+dmA+w5DHvUmBgkr5rM/KCHpCsiFNRUfokW/szpPPgMK2hm4A==",
 			"dev": true
 		},
 		"balanced-match": {
@@ -462,9 +445,9 @@
 			"integrity": "sha1-PkC4FmP4HS3WWWpMtxSo3BbPq+A="
 		},
 		"buffer": {
-			"version": "5.4.2",
-			"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.4.2.tgz",
-			"integrity": "sha512-iy9koArjAFCzGnx3ZvNA6Z0clIbbFgbdWQ0mKD3hO0krOrZh8UgA6qMKcZvwLJxS+D6iVR76+5/pV56yMNYTag==",
+			"version": "5.4.3",
+			"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.4.3.tgz",
+			"integrity": "sha512-zvj65TkFeIt3i6aj5bIvJDzjjQQGs4o/sNoezg1F1kYap9Nu2jcUdpwzRSJTHMMzG0H7bZkn4rNQpImhuxWX2A==",
 			"requires": {
 				"base64-js": "^1.0.2",
 				"ieee754": "^1.1.4"
@@ -507,12 +490,6 @@
 			"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
 			"dev": true
 		},
-		"capture-stack-trace": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.1.tgz",
-			"integrity": "sha512-mYQLZnx5Qt1JgB1WEiMCf2647plpGeQ2NMR/5L0HNZzGQo4fuSPnK+wjfPnKZV0aiJDgzmWqqkV/g7JD+DW0qw==",
-			"dev": true
-		},
 		"caseless": {
 			"version": "0.12.0",
 			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
@@ -535,19 +512,19 @@
 			"integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc="
 		},
 		"chokidar": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.0.2.tgz",
-			"integrity": "sha512-c4PR2egjNjI1um6bamCQ6bUNPDiyofNQruHvKgHQ4gDUP/ITSVSzNsiI5OWtHOsX323i5ha/kk4YmOZ1Ktg7KA==",
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.3.1.tgz",
+			"integrity": "sha512-4QYCEWOcK3OJrxwvyyAOxFuhpvOVCYkr33LPfFNBjAD/w3sEzWsp2BUOkI4l9bHvWioAd0rc6NlHUOEaWkTeqg==",
 			"dev": true,
 			"requires": {
-				"anymatch": "^3.0.1",
-				"braces": "^3.0.2",
-				"fsevents": "^2.0.6",
-				"glob-parent": "^5.0.0",
-				"is-binary-path": "^2.1.0",
-				"is-glob": "^4.0.1",
-				"normalize-path": "^3.0.0",
-				"readdirp": "^3.1.1"
+				"anymatch": "~3.1.1",
+				"braces": "~3.0.2",
+				"fsevents": "~2.1.2",
+				"glob-parent": "~5.1.0",
+				"is-binary-path": "~2.1.0",
+				"is-glob": "~4.0.1",
+				"normalize-path": "~3.0.0",
+				"readdirp": "~3.3.0"
 			}
 		},
 		"cldrjs": {
@@ -602,9 +579,9 @@
 			}
 		},
 		"commander": {
-			"version": "2.20.0",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
-			"integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
+			"version": "2.20.3",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
 			"dev": true,
 			"optional": true
 		},
@@ -620,9 +597,9 @@
 			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
 		},
 		"convert-source-map": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
-			"integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
+			"integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
 			"dev": true,
 			"requires": {
 				"safe-buffer": "~5.1.1"
@@ -642,9 +619,9 @@
 			"integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
 		},
 		"core-js": {
-			"version": "2.6.9",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
-			"integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A=="
+			"version": "2.6.11",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
+			"integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
 		},
 		"core-util-is": {
 			"version": "1.0.2",
@@ -653,17 +630,16 @@
 			"dev": true
 		},
 		"coveralls": {
-			"version": "3.0.6",
-			"resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.0.6.tgz",
-			"integrity": "sha512-Pgh4v3gCI4T/9VijVrm8Ym5v0OgjvGLKj3zTUwkvsCiwqae/p6VLzpsFNjQS2i6ewV7ef+DjFJ5TSKxYt/mCrA==",
+			"version": "3.0.9",
+			"resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.0.9.tgz",
+			"integrity": "sha512-nNBg3B1+4iDox5A5zqHKzUTiwl2ey4k2o0NEcVZYvl+GOSJdKBj4AJGKLv6h3SvWch7tABHePAQOSZWM9E2hMg==",
 			"dev": true,
 			"requires": {
-				"growl": "~> 1.10.0",
 				"js-yaml": "^3.13.1",
-				"lcov-parse": "^0.0.10",
+				"lcov-parse": "^1.0.0",
 				"log-driver": "^1.2.7",
 				"minimist": "^1.2.0",
-				"request": "^2.86.0"
+				"request": "^2.88.0"
 			}
 		},
 		"cp-file": {
@@ -696,6 +672,17 @@
 			"requires": {
 				"lru-cache": "^4.0.1",
 				"which": "^1.2.9"
+			},
+			"dependencies": {
+				"which": {
+					"version": "1.3.1",
+					"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+					"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+					"dev": true,
+					"requires": {
+						"isexe": "^2.0.0"
+					}
+				}
 			}
 		},
 		"crypt": {
@@ -727,9 +714,9 @@
 			"dev": true
 		},
 		"deep-equal": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.0.tgz",
-			"integrity": "sha512-ZbfWJq/wN1Z273o7mUSjILYqehAktR2NVoSrOukDkU9kg2v/Uv89yU4Cvz8seJeAmtN5oqiefKq8FPuXOboqLw==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-1.1.1.tgz",
+			"integrity": "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==",
 			"requires": {
 				"is-arguments": "^1.0.4",
 				"is-date-object": "^1.0.1",
@@ -777,10 +764,16 @@
 			"integrity": "sha512-s2+XdvhPCOF01LRQBC8hf4vhbVmI2CGS5aZnxLJlT5FtdhPCDFq80q++zK2KlrVorVDdL5BOGZ/VfLrVtYNF+Q==",
 			"dev": true
 		},
+		"diff-frag": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/diff-frag/-/diff-frag-1.0.1.tgz",
+			"integrity": "sha512-6/v2PC/6UTGcWPPetb9acL8foberUg/CtPdALeJUdD1B/weHNvzftoo00gYznqHGRhHEbykUGzqfG9RWOSr5yw==",
+			"dev": true
+		},
 		"dom-serializer": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.2.1.tgz",
-			"integrity": "sha512-sK3ujri04WyjwQXVoK4PU3y8ula1stq10GJZpqHIUgoGZdsGzAGu65BnU3d08aTVSvO7mGPZUc0wTEDL+qGE0Q==",
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.2.2.tgz",
+			"integrity": "sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==",
 			"requires": {
 				"domelementtype": "^2.0.1",
 				"entities": "^2.0.0"
@@ -864,22 +857,27 @@
 			}
 		},
 		"es-abstract": {
-			"version": "1.13.0",
-			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz",
-			"integrity": "sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==",
+			"version": "1.17.0",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.0.tgz",
+			"integrity": "sha512-yYkE07YF+6SIBmg1MsJ9dlub5L48Ek7X0qz+c/CPCHS9EBXfESorzng4cJQjJW5/pB6vDF41u7F8vUhLVDqIug==",
 			"requires": {
-				"es-to-primitive": "^1.2.0",
+				"es-to-primitive": "^1.2.1",
 				"function-bind": "^1.1.1",
 				"has": "^1.0.3",
-				"is-callable": "^1.1.4",
-				"is-regex": "^1.0.4",
-				"object-keys": "^1.0.12"
+				"has-symbols": "^1.0.1",
+				"is-callable": "^1.1.5",
+				"is-regex": "^1.0.5",
+				"object-inspect": "^1.7.0",
+				"object-keys": "^1.1.1",
+				"object.assign": "^4.1.0",
+				"string.prototype.trimleft": "^2.1.1",
+				"string.prototype.trimright": "^2.1.1"
 			}
 		},
 		"es-to-primitive": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.0.tgz",
-			"integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+			"integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
 			"requires": {
 				"is-callable": "^1.1.4",
 				"is-date-object": "^1.0.1",
@@ -899,9 +897,9 @@
 			"dev": true
 		},
 		"escodegen": {
-			"version": "1.12.0",
-			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.12.0.tgz",
-			"integrity": "sha512-TuA+EhsanGcme5T3R0L80u4t8CpbXQjegRmf7+FPTJrtCTErXFeelblRgHQa1FofEzqYYJmJ/OqjTwREp9qgmg==",
+			"version": "1.12.1",
+			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.12.1.tgz",
+			"integrity": "sha512-Q8t2YZ+0e0pc7NRVj3B4tSQ9rim1oi4Fh46k2xhJ2qOiEwhQfdjyEQddWdj7ZFaKmU+5104vn1qrcjEPWq+bgQ==",
 			"requires": {
 				"esprima": "^3.1.3",
 				"estraverse": "^4.2.0",
@@ -971,9 +969,9 @@
 			}
 		},
 		"fast-json-stable-stringify": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-			"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
 			"dev": true
 		},
 		"fast-levenshtein": {
@@ -1017,18 +1015,18 @@
 			"dev": true
 		},
 		"flow-parser": {
-			"version": "0.107.0",
-			"resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.107.0.tgz",
-			"integrity": "sha512-GtMCS8qzP0VskiE5qfN4zYiwjnClV/BxPZ4zUqMRUfyaF+gBuLHDTPqVLJ4ndGedrdv54510rsXDSbkCqUig+g==",
+			"version": "0.115.0",
+			"resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.115.0.tgz",
+			"integrity": "sha512-iasokPUPxp4ojhMaxN215jgp9VFliai+2YVLW3gXN5Yhb/t+QC7Z/CaKBwrrWqainfnl9SH+gr3mSGoq+IXWLQ==",
 			"dev": true
 		},
 		"flow-remove-types": {
-			"version": "2.107.0",
-			"resolved": "https://registry.npmjs.org/flow-remove-types/-/flow-remove-types-2.107.0.tgz",
-			"integrity": "sha512-PXsYEHt5gKuFxw4rSc5e0K2OxhR7JxploCQ4wQzu7wE/Fw42oOs7sdGHPZujTeBY/g3OYSoZ11YxK3KoTHIYWw==",
+			"version": "2.115.0",
+			"resolved": "https://registry.npmjs.org/flow-remove-types/-/flow-remove-types-2.115.0.tgz",
+			"integrity": "sha512-7yf0sQEV/KwXnt/Zs0D40eJORIMQLNztTUBGqb5GvOIIiOStcw8y/yi03Jw0VOwiI7GVqFoONtsCVawQvCrteg==",
 			"dev": true,
 			"requires": {
-				"flow-parser": "^0.107.0",
+				"flow-parser": "^0.115.0",
 				"pirates": "^3.0.2",
 				"vlq": "^0.2.1"
 			}
@@ -1081,9 +1079,9 @@
 			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
 		},
 		"fsevents": {
-			"version": "2.0.7",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.0.7.tgz",
-			"integrity": "sha512-a7YT0SV3RB+DjYcppwVDLtn13UQnmg0SWZS7ezZD0UjnLwXmy8Zm21GMVGLaFGimIqcvyMQaOJBrop8MyOp1kQ==",
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.2.tgz",
+			"integrity": "sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA==",
 			"dev": true,
 			"optional": true
 		},
@@ -1133,9 +1131,9 @@
 			}
 		},
 		"glob": {
-			"version": "7.1.4",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
-			"integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+			"version": "7.1.6",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+			"integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
 			"requires": {
 				"fs.realpath": "^1.0.0",
 				"inflight": "^1.0.4",
@@ -1146,9 +1144,9 @@
 			}
 		},
 		"glob-parent": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.0.0.tgz",
-			"integrity": "sha512-Z2RwiujPRGluePM6j699ktJYxmPpJKCfpGA13jz2hmFZC7gKetzrWvg5KN3+OsIFmydGyZ1AVwERCq1w/ZZwRg==",
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.0.tgz",
+			"integrity": "sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==",
 			"dev": true,
 			"requires": {
 				"is-glob": "^4.0.1"
@@ -1169,21 +1167,15 @@
 			"dev": true
 		},
 		"graceful-fs": {
-			"version": "4.2.2",
-			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.2.tgz",
-			"integrity": "sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q==",
-			"dev": true
-		},
-		"growl": {
-			"version": "1.10.5",
-			"resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
-			"integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
+			"integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
 			"dev": true
 		},
 		"handlebars": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.2.0.tgz",
-			"integrity": "sha512-Kb4xn5Qh1cxAKvQnzNWZ512DhABzyFNmsaJf3OAkWNa4NkaqWcNI8Tao8Tasi0/F4JD9oyG0YxuFyvyR57d+Gw==",
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.6.0.tgz",
+			"integrity": "sha512-i1ZUP7Qp2JdkMaFon2a+b0m5geE8Z4ZTLaGkgrObkEd+OkUKyRbRWw4KxuFCoHfdETSY1yf9/574eVoNSiK7pw==",
 			"dev": true,
 			"requires": {
 				"neo-async": "^2.6.0",
@@ -1223,9 +1215,9 @@
 			"dev": true
 		},
 		"has-symbols": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
-			"integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q="
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+			"integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
 		},
 		"hasha": {
 			"version": "3.0.0",
@@ -1245,9 +1237,9 @@
 			}
 		},
 		"hosted-git-info": {
-			"version": "2.8.4",
-			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.4.tgz",
-			"integrity": "sha512-pzXIvANXEFrc5oFFXRMkbLPQ2rXRoDERwDLyrcUxGhaZhgP54BBSl9Oheh7Vv0T090cszWBxPjkQQ5Sq1PbBRQ==",
+			"version": "2.8.5",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.5.tgz",
+			"integrity": "sha512-kssjab8CvdXfcXMXVcvsXum4Hwdq9XGtRD3TteMEvEbq0LXyiNQr6AprqKqfeaDXze7SxWvRxdpwE6ku7ikLkg==",
 			"dev": true
 		},
 		"htmlparser2": {
@@ -1261,18 +1253,6 @@
 				"entities": "^1.1.1",
 				"inherits": "^2.0.1",
 				"readable-stream": "^3.1.1"
-			},
-			"dependencies": {
-				"readable-stream": {
-					"version": "3.4.0",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
-					"integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
-					"requires": {
-						"inherits": "^2.0.3",
-						"string_decoder": "^1.1.1",
-						"util-deprecate": "^1.0.1"
-					}
-				}
 			}
 		},
 		"http-signature": {
@@ -1360,14 +1340,14 @@
 			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
 		},
 		"is-callable": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
-			"integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA=="
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
+			"integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q=="
 		},
 		"is-date-object": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-			"integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.2.tgz",
+			"integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g=="
 		},
 		"is-extglob": {
 			"version": "2.1.1",
@@ -1397,11 +1377,11 @@
 			"dev": true
 		},
 		"is-regex": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
-			"integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
+			"integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
 			"requires": {
-				"has": "^1.0.1"
+				"has": "^1.0.3"
 			}
 		},
 		"is-stream": {
@@ -1410,11 +1390,11 @@
 			"integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw=="
 		},
 		"is-symbol": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
-			"integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
+			"integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
 			"requires": {
-				"has-symbols": "^1.0.0"
+				"has-symbols": "^1.0.1"
 			}
 		},
 		"is-typedarray": {
@@ -1422,13 +1402,6 @@
 			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
 			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
 			"dev": true
-		},
-		"isarray": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-			"dev": true,
-			"optional": true
 		},
 		"isexe": {
 			"version": "2.0.0",
@@ -1521,6 +1494,15 @@
 					"dev": true,
 					"requires": {
 						"glob": "^7.1.3"
+					}
+				},
+				"which": {
+					"version": "1.3.1",
+					"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+					"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+					"dev": true,
+					"requires": {
+						"isexe": "^2.0.0"
 					}
 				}
 			}
@@ -1653,9 +1635,9 @@
 			}
 		},
 		"lcov-parse": {
-			"version": "0.0.10",
-			"resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-0.0.10.tgz",
-			"integrity": "sha1-GwuP+ayceIklBYK3C3ExXZ2m2aM=",
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-1.0.0.tgz",
+			"integrity": "sha1-6w1GtUER68VhrLTECO+TY73I9+A=",
 			"dev": true
 		},
 		"levn": {
@@ -1766,6 +1748,15 @@
 			"integrity": "sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg==",
 			"dev": true
 		},
+		"loose-envify": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+			"integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+			"dev": true,
+			"requires": {
+				"js-tokens": "^3.0.0 || ^4.0.0"
+			}
+		},
 		"lru-cache": {
 			"version": "4.1.5",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
@@ -1812,16 +1803,16 @@
 			}
 		},
 		"mime-db": {
-			"version": "1.40.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
-			"integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA=="
+			"version": "1.43.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.43.0.tgz",
+			"integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ=="
 		},
 		"mime-types": {
-			"version": "2.1.24",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
-			"integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
+			"version": "2.1.26",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.26.tgz",
+			"integrity": "sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==",
 			"requires": {
-				"mime-db": "1.40.0"
+				"mime-db": "1.43.0"
 			}
 		},
 		"minimatch": {
@@ -1838,19 +1829,18 @@
 			"integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
 		},
 		"minipass": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-2.5.1.tgz",
-			"integrity": "sha512-dmpSnLJtNQioZFI5HfQ55Ad0DzzsMAb+HfokwRTNXwEQjepbTkl5mtIlSVxGIkOkxlpX7wIn5ET/oAd9fZ/Y/Q==",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.1.tgz",
+			"integrity": "sha512-UFqVihv6PQgwj8/yTGvl9kPz7xIAY+R5z6XYjRInD3Gk3qx6QGSD6zEcpeG4Dy/lQnv1J6zv8ejV90hyYIKf3w==",
 			"dev": true,
 			"requires": {
-				"safe-buffer": "^5.1.2",
-				"yallist": "^3.0.0"
+				"yallist": "^4.0.0"
 			},
 			"dependencies": {
 				"yallist": {
-					"version": "3.0.3",
-					"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
-					"integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
 					"dev": true
 				}
 			}
@@ -2004,23 +1994,45 @@
 			"integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
 			"dev": true
 		},
+		"object-assign": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+			"dev": true
+		},
+		"object-inspect": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
+			"integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw=="
+		},
 		"object-is": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/object-is/-/object-is-1.0.1.tgz",
-			"integrity": "sha1-CqYOyZiaCz7Xlc9NBvYs8a1lObY="
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/object-is/-/object-is-1.0.2.tgz",
+			"integrity": "sha512-Epah+btZd5wrrfjkJZq1AOB9O6OxUQto45hzFd7lXGrpHPGE0W1k+426yrZV+k6NJOzLNNW/nVsmZdIWsAqoOQ=="
 		},
 		"object-keys": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
 			"integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
 		},
-		"object.getownpropertydescriptors": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
-			"integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
+		"object.assign": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+			"integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
 			"requires": {
 				"define-properties": "^1.1.2",
-				"es-abstract": "^1.5.1"
+				"function-bind": "^1.1.1",
+				"has-symbols": "^1.0.0",
+				"object-keys": "^1.0.11"
+			}
+		},
+		"object.getownpropertydescriptors": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.0.tgz",
+			"integrity": "sha512-Z53Oah9A3TdLoblT7VKJaTDdXdT+lQO+cNpKVnya5JDe9uLvzu1YyY1yFDFrcxrlRgWrEFH0jJtD/IbuwjcEVg==",
+			"requires": {
+				"define-properties": "^1.1.3",
+				"es-abstract": "^1.17.0-next.1"
 			}
 		},
 		"once": {
@@ -2050,25 +2062,20 @@
 					"version": "0.0.10",
 					"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
 					"integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
-				},
-				"wordwrap": {
-					"version": "0.0.3",
-					"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-					"integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
 				}
 			}
 		},
 		"optionator": {
-			"version": "0.8.2",
-			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
-			"integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+			"version": "0.8.3",
+			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
+			"integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
 			"requires": {
 				"deep-is": "~0.1.3",
-				"fast-levenshtein": "~2.0.4",
+				"fast-levenshtein": "~2.0.6",
 				"levn": "~0.3.0",
 				"prelude-ls": "~1.1.2",
 				"type-check": "~0.3.2",
-				"wordwrap": "~1.0.0"
+				"word-wrap": "~1.2.3"
 			}
 		},
 		"os-homedir": {
@@ -2093,9 +2100,9 @@
 			}
 		},
 		"p-limit": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
-			"integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
+			"integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
 			"dev": true,
 			"requires": {
 				"p-try": "^2.0.0"
@@ -2185,9 +2192,9 @@
 			"dev": true
 		},
 		"picomatch": {
-			"version": "2.0.7",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.0.7.tgz",
-			"integrity": "sha512-oLHIdio3tZ0qH76NybpeneBhYVj0QFTfXEFTc/B3zKQspYfYYkWYgFsmzo+4kvId/bQRcNkVeguI3y+CD22BtA==",
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.1.tgz",
+			"integrity": "sha512-ISBaA8xQNmwELC7eOjqFKMESB2VIqt4PPDD0nsS95b/9dZXvVKOlz9keMSnoGGKcOHXfTvDD6WMaRoSc9UuhRA==",
 			"dev": true
 		},
 		"pify": {
@@ -2219,12 +2226,16 @@
 			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
 			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
 		},
-		"process-nextick-args": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+		"prop-types": {
+			"version": "15.7.2",
+			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+			"integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
 			"dev": true,
-			"optional": true
+			"requires": {
+				"loose-envify": "^1.4.0",
+				"object-assign": "^4.1.1",
+				"react-is": "^16.8.1"
+			}
 		},
 		"pseudomap": {
 			"version": "1.0.2",
@@ -2233,9 +2244,9 @@
 			"dev": true
 		},
 		"psl": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/psl/-/psl-1.4.0.tgz",
-			"integrity": "sha512-HZzqCGPecFLyoRj5HLfuDSKYTJkAfB5thKBIkRHtGjWwY7p1dAyveIbXIq4tO0KYfDF2tHqPUgY9SDnGm00uFw==",
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/psl/-/psl-1.7.0.tgz",
+			"integrity": "sha512-5NsSEDv8zY70ScRnOTn7bK7eanl2MvFrOrS/R6x+dBt5g1ghnj9Zv90kO8GwT8gxcu2ANyFprnFYB85IogIJOQ==",
 			"dev": true
 		},
 		"punycode": {
@@ -2244,9 +2255,9 @@
 			"integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
 		},
 		"qs": {
-			"version": "6.8.0",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.8.0.tgz",
-			"integrity": "sha512-tPSkj8y92PfZVbinY1n84i1Qdx75lZjMQYx9WZhnkofyxzw2r7Ho39G3/aEvSUdebxpnnM4LZJCtvE/Aq3+s9w=="
+			"version": "6.9.1",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.9.1.tgz",
+			"integrity": "sha512-Cxm7/SS/y/Z3MHWSxXb8lIFqgqBowP5JMlTUFyJN88y0SGQhVmZnqFK/PeuMX9LzUyWsqqhNxIyg0jlzq946yA=="
 		},
 		"querystring": {
 			"version": "0.2.0",
@@ -2257,6 +2268,23 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/querystring-browser/-/querystring-browser-1.0.4.tgz",
 			"integrity": "sha1-8uNYgYQKgZvHsb9Zf68JeeZiLcY="
+		},
+		"react": {
+			"version": "16.12.0",
+			"resolved": "https://registry.npmjs.org/react/-/react-16.12.0.tgz",
+			"integrity": "sha512-fglqy3k5E+81pA8s+7K0/T3DBCF0ZDOher1elBFzF7O6arXJgzyu/FW+COxFvAWXJoJN9KIZbT2LXlukwphYTA==",
+			"dev": true,
+			"requires": {
+				"loose-envify": "^1.1.0",
+				"object-assign": "^4.1.1",
+				"prop-types": "^15.6.2"
+			}
+		},
+		"react-is": {
+			"version": "16.12.0",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.12.0.tgz",
+			"integrity": "sha512-rPCkf/mWBtKc97aLL9/txD8DZdemK0vkA3JMLShjlJB3Pj3s+lpf1KaBzMfQrAmhMQB0n1cU/SUGgKKBCe837Q==",
+			"dev": true
 		},
 		"read-pkg": {
 			"version": "3.0.0",
@@ -2280,37 +2308,22 @@
 			}
 		},
 		"readable-stream": {
-			"version": "2.3.6",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-			"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-			"dev": true,
-			"optional": true,
+			"version": "3.4.0",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+			"integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
 			"requires": {
-				"core-util-is": "~1.0.0",
-				"inherits": "~2.0.3",
-				"isarray": "~1.0.0",
-				"process-nextick-args": "~2.0.0",
-				"safe-buffer": "~5.1.1",
-				"string_decoder": "~1.1.1",
-				"util-deprecate": "~1.0.1"
-			},
-			"dependencies": {
-				"safe-buffer": {
-					"version": "5.1.2",
-					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-					"dev": true,
-					"optional": true
-				}
+				"inherits": "^2.0.3",
+				"string_decoder": "^1.1.1",
+				"util-deprecate": "^1.0.1"
 			}
 		},
 		"readdirp": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.1.2.tgz",
-			"integrity": "sha512-8rhl0xs2cxfVsqzreYCvs8EwBfn/DhVdqtoLmw19uI3SC5avYX9teCurlErfpPXGmYtMHReGaP2RsLnFvz/lnw==",
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.3.0.tgz",
+			"integrity": "sha512-zz0pAkSPOXXm1viEwygWIPSPkcBYjW1xU5j/JBh5t9bGCJwa6f9+BJa6VaB2g+b55yVrmXzqkyLf4xaWYM0IkQ==",
 			"dev": true,
 			"requires": {
-				"picomatch": "^2.0.4"
+				"picomatch": "^2.0.7"
 			}
 		},
 		"rechoir": {
@@ -2328,11 +2341,12 @@
 			"integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
 		},
 		"regexp.prototype.flags": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.2.0.tgz",
-			"integrity": "sha512-ztaw4M1VqgMwl9HlPpOuiYgItcHlunW0He2fE6eNfT6E/CF2FtYi9ofOYe4mKntstYk0Fyh/rDRBdS3AnxjlrA==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.0.tgz",
+			"integrity": "sha512-2+Q0C5g951OlYlJz6yu5/M33IcsESLlLfsyIaLJaG4FA2r4yP8MvVMJUUP/fVBkSpbbbZlS5gynbEWLipiiXiQ==",
 			"requires": {
-				"define-properties": "^1.1.2"
+				"define-properties": "^1.1.3",
+				"es-abstract": "^1.17.0-next.1"
 			}
 		},
 		"release-zalgo": {
@@ -2404,9 +2418,9 @@
 			"dev": true
 		},
 		"resolve": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.1.tgz",
-			"integrity": "sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==",
+			"version": "1.14.2",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.14.2.tgz",
+			"integrity": "sha512-EjlOBLBO1kxsUxsKjLt7TAECyKW6fOh1VRkykQkKGzcBbjjPIxBqGh0jf7GJ3k/f5mxMqW3htMD3WdTUVtW8HQ==",
 			"dev": true,
 			"requires": {
 				"path-parse": "^1.0.6"
@@ -2430,8 +2444,7 @@
 		"safe-buffer": {
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
-			"integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==",
-			"dev": true
+			"integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
 		},
 		"safer-buffer": {
 			"version": "2.1.2",
@@ -2488,9 +2501,9 @@
 			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 		},
 		"source-map-support": {
-			"version": "0.5.13",
-			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
-			"integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
+			"version": "0.5.16",
+			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.16.tgz",
+			"integrity": "sha512-efyLRJDr68D9hBBNIPWFjhpFzURh+KJykQwvMyW5UiZzYwoF6l4YMMDIJJEyFWxWCqfyxLzz6tSfUFR+kXXsVQ==",
 			"dev": true,
 			"requires": {
 				"buffer-from": "^1.0.0",
@@ -2518,6 +2531,15 @@
 					"dev": true,
 					"requires": {
 						"glob": "^7.1.3"
+					}
+				},
+				"which": {
+					"version": "1.3.1",
+					"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+					"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+					"dev": true,
+					"requires": {
+						"isexe": "^2.0.0"
 					}
 				}
 			}
@@ -2600,19 +2622,30 @@
 				"strip-ansi": "^4.0.0"
 			}
 		},
-		"string_decoder": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+		"string.prototype.trimleft": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.1.tgz",
+			"integrity": "sha512-iu2AGd3PuP5Rp7x2kEZCrB2Nf41ehzh+goo8TV7z8/XDBbsvc6HQIlUl9RjkZ4oyrW1XM5UwlGl1oVEaDjg6Ag==",
 			"requires": {
-				"safe-buffer": "~5.1.0"
-			},
-			"dependencies": {
-				"safe-buffer": {
-					"version": "5.1.2",
-					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-				}
+				"define-properties": "^1.1.3",
+				"function-bind": "^1.1.1"
+			}
+		},
+		"string.prototype.trimright": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.1.tgz",
+			"integrity": "sha512-qFvWL3/+QIgZXVmJBfpHmxLB7xsUXz6HsUmP8+5dRaC3Q7oKUv9Vo6aMCRZC1smrtyECFsIT30PqBJ1gTjAs+g==",
+			"requires": {
+				"define-properties": "^1.1.3",
+				"function-bind": "^1.1.1"
+			}
+		},
+		"string_decoder": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+			"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+			"requires": {
+				"safe-buffer": "~5.2.0"
 			}
 		},
 		"strip-ansi": {
@@ -2640,9 +2673,9 @@
 			}
 		},
 		"swagger-client": {
-			"version": "3.9.4",
-			"resolved": "https://registry.npmjs.org/swagger-client/-/swagger-client-3.9.4.tgz",
-			"integrity": "sha512-Rd4BrAUQeVIFYqzg7lkJMpd1P/oMVzcXEaKKaD+hfF8x4ZTTElNClCikD2yjFvmRCx0J2eIWs908kQOPkwc63w==",
+			"version": "3.9.6",
+			"resolved": "https://registry.npmjs.org/swagger-client/-/swagger-client-3.9.6.tgz",
+			"integrity": "sha512-aS01VInNv6I+/DVQ++7TCwunYGWM/uiQNNPO0L+1+MfA3r0UEHYc9XJ8aXmrhXCvQ1jdY626ePch3plwhTunUQ==",
 			"requires": {
 				"@babel/runtime-corejs2": "^7.0.0",
 				"@kyleshockey/object-assign-deep": "^0.4.0",
@@ -2665,78 +2698,294 @@
 			}
 		},
 		"tap": {
-			"version": "14.6.2",
-			"resolved": "https://registry.npmjs.org/tap/-/tap-14.6.2.tgz",
-			"integrity": "sha512-vGtyUcTXsmqKCv1Cn+noln3Qz3UucIA/1jO3oKR1UDHOC928+HWTmxJt7VkSyXk+ZYoltqVOYTW0BI4iMipzjw==",
+			"version": "14.10.5",
+			"resolved": "https://registry.npmjs.org/tap/-/tap-14.10.5.tgz",
+			"integrity": "sha512-8I8zMFEVu7e7RVcjK1GUNf1vW+6B9TRCZWGgif5siMBfvwTE9/EPN/7aH6W2r+WR2H2YHXcrCJ3XhRitYEVKfQ==",
 			"dev": true,
 			"requires": {
-				"async-hook-domain": "^1.1.0",
+				"@types/react": "^16.9.16",
+				"async-hook-domain": "^1.1.3",
 				"bind-obj-methods": "^2.0.0",
 				"browser-process-hrtime": "^1.0.0",
-				"capture-stack-trace": "^1.0.0",
-				"chokidar": "^3.0.2",
+				"chokidar": "^3.3.0",
 				"color-support": "^1.1.0",
-				"coveralls": "^3.0.5",
+				"coveralls": "^3.0.8",
 				"diff": "^4.0.1",
 				"esm": "^3.2.25",
 				"findit": "^2.0.0",
-				"flow-remove-types": "^2.101.0",
+				"flow-remove-types": "^2.112.0",
 				"foreground-child": "^1.3.3",
 				"fs-exists-cached": "^1.0.0",
 				"function-loop": "^1.0.2",
-				"glob": "^7.1.4",
-				"import-jsx": "^2.0.0",
-				"ink": "^2.3.0",
+				"glob": "^7.1.6",
+				"import-jsx": "^3.0.0",
+				"ink": "^2.5.0",
 				"isexe": "^2.0.0",
 				"istanbul-lib-processinfo": "^1.0.0",
 				"jackspeak": "^1.4.0",
-				"minipass": "^2.3.5",
+				"minipass": "^3.1.1",
 				"mkdirp": "^0.5.1",
 				"nyc": "^14.1.1",
 				"opener": "^1.5.1",
 				"own-or": "^1.0.0",
 				"own-or-env": "^1.0.1",
-				"react": "^16.8.6",
-				"rimraf": "^2.6.3",
+				"react": "^16.12.0",
+				"rimraf": "^2.7.1",
 				"signal-exit": "^3.0.0",
-				"source-map-support": "^0.5.12",
+				"source-map-support": "^0.5.16",
 				"stack-utils": "^1.0.2",
-				"tap-mocha-reporter": "^4.0.1",
-				"tap-parser": "^9.3.2",
+				"tap-mocha-reporter": "^5.0.0",
+				"tap-parser": "^10.0.1",
 				"tap-yaml": "^1.0.0",
-				"tcompare": "^2.3.0",
-				"treport": "^0.4.0",
+				"tcompare": "^3.0.0",
+				"treport": "^1.0.1",
 				"trivial-deferred": "^1.0.1",
-				"ts-node": "^8.3.0",
-				"typescript": "^3.5.3",
-				"which": "^1.3.1",
-				"write-file-atomic": "^3.0.0",
-				"yaml": "^1.6.0",
+				"ts-node": "^8.5.2",
+				"typescript": "^3.7.2",
+				"which": "^2.0.2",
+				"write-file-atomic": "^3.0.1",
+				"yaml": "^1.7.2",
 				"yapool": "^1.0.0"
 			},
 			"dependencies": {
-				"@babel/runtime": {
-					"version": "7.4.5",
+				"@babel/code-frame": {
+					"version": "7.5.5",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"regenerator-runtime": "^0.13.2"
+						"@babel/highlight": "^7.0.0"
+					}
+				},
+				"@babel/core": {
+					"version": "7.7.5",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.5.5",
+						"@babel/generator": "^7.7.4",
+						"@babel/helpers": "^7.7.4",
+						"@babel/parser": "^7.7.5",
+						"@babel/template": "^7.7.4",
+						"@babel/traverse": "^7.7.4",
+						"@babel/types": "^7.7.4",
+						"convert-source-map": "^1.7.0",
+						"debug": "^4.1.0",
+						"json5": "^2.1.0",
+						"lodash": "^4.17.13",
+						"resolve": "^1.3.2",
+						"semver": "^5.4.1",
+						"source-map": "^0.5.0"
 					},
 					"dependencies": {
-						"regenerator-runtime": {
-							"version": "0.13.2",
+						"source-map": {
+							"version": "0.5.7",
 							"bundled": true,
 							"dev": true
 						}
 					}
 				},
+				"@babel/generator": {
+					"version": "7.7.4",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.7.4",
+						"jsesc": "^2.5.1",
+						"lodash": "^4.17.13",
+						"source-map": "^0.5.0"
+					},
+					"dependencies": {
+						"source-map": {
+							"version": "0.5.7",
+							"bundled": true,
+							"dev": true
+						}
+					}
+				},
+				"@babel/helper-builder-react-jsx": {
+					"version": "7.7.4",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.7.4",
+						"esutils": "^2.0.0"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.7.4",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"@babel/helper-get-function-arity": "^7.7.4",
+						"@babel/template": "^7.7.4",
+						"@babel/types": "^7.7.4"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.7.4",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.7.4"
+					}
+				},
+				"@babel/helper-plugin-utils": {
+					"version": "7.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.7.4",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.7.4"
+					}
+				},
+				"@babel/helpers": {
+					"version": "7.7.4",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"@babel/template": "^7.7.4",
+						"@babel/traverse": "^7.7.4",
+						"@babel/types": "^7.7.4"
+					}
+				},
+				"@babel/highlight": {
+					"version": "7.5.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"chalk": "^2.0.0",
+						"esutils": "^2.0.2",
+						"js-tokens": "^4.0.0"
+					},
+					"dependencies": {
+						"chalk": {
+							"version": "2.4.2",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"ansi-styles": "^3.2.1",
+								"escape-string-regexp": "^1.0.5",
+								"supports-color": "^5.3.0"
+							}
+						},
+						"supports-color": {
+							"version": "5.5.0",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"has-flag": "^3.0.0"
+							}
+						}
+					}
+				},
+				"@babel/parser": {
+					"version": "7.7.5",
+					"bundled": true,
+					"dev": true
+				},
+				"@babel/plugin-proposal-object-rest-spread": {
+					"version": "7.7.4",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0",
+						"@babel/plugin-syntax-object-rest-spread": "^7.7.4"
+					}
+				},
+				"@babel/plugin-syntax-jsx": {
+					"version": "7.7.4",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-syntax-object-rest-spread": {
+					"version": "7.7.4",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-transform-destructuring": {
+					"version": "7.7.4",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-transform-react-jsx": {
+					"version": "7.7.4",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"@babel/helper-builder-react-jsx": "^7.7.4",
+						"@babel/helper-plugin-utils": "^7.0.0",
+						"@babel/plugin-syntax-jsx": "^7.7.4"
+					}
+				},
+				"@babel/runtime": {
+					"version": "7.7.6",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"regenerator-runtime": "^0.13.2"
+					}
+				},
+				"@babel/template": {
+					"version": "7.7.4",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.0.0",
+						"@babel/parser": "^7.7.4",
+						"@babel/types": "^7.7.4"
+					}
+				},
+				"@babel/traverse": {
+					"version": "7.7.4",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.5.5",
+						"@babel/generator": "^7.7.4",
+						"@babel/helper-function-name": "^7.7.4",
+						"@babel/helper-split-export-declaration": "^7.7.4",
+						"@babel/parser": "^7.7.4",
+						"@babel/types": "^7.7.4",
+						"debug": "^4.1.0",
+						"globals": "^11.1.0",
+						"lodash": "^4.17.13"
+					}
+				},
+				"@babel/types": {
+					"version": "7.7.4",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.13",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"@types/color-name": {
+					"version": "1.1.1",
+					"bundled": true,
+					"dev": true
+				},
 				"@types/prop-types": {
-					"version": "15.7.1",
+					"version": "15.7.3",
 					"bundled": true,
 					"dev": true
 				},
 				"@types/react": {
-					"version": "16.8.22",
+					"version": "16.9.16",
 					"bundled": true,
 					"dev": true,
 					"requires": {
@@ -2745,19 +2994,25 @@
 					}
 				},
 				"ansi-escapes": {
-					"version": "3.2.0",
+					"version": "4.3.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"requires": {
+						"type-fest": "^0.8.1"
+					}
 				},
 				"ansi-regex": {
-					"version": "2.1.1",
+					"version": "5.0.0",
 					"bundled": true,
 					"dev": true
 				},
 				"ansi-styles": {
-					"version": "2.2.1",
+					"version": "3.2.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"requires": {
+						"color-convert": "^1.9.0"
+					}
 				},
 				"ansicolors": {
 					"version": "0.3.2",
@@ -2765,247 +3020,19 @@
 					"dev": true
 				},
 				"arrify": {
-					"version": "1.0.1",
+					"version": "2.0.1",
 					"bundled": true,
 					"dev": true
 				},
 				"astral-regex": {
-					"version": "1.0.0",
+					"version": "2.0.0",
 					"bundled": true,
 					"dev": true
 				},
 				"auto-bind": {
-					"version": "2.1.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"@types/react": "^16.8.12"
-					}
-				},
-				"babel-code-frame": {
-					"version": "6.26.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"chalk": "^1.1.3",
-						"esutils": "^2.0.2",
-						"js-tokens": "^3.0.2"
-					}
-				},
-				"babel-core": {
-					"version": "6.26.3",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"babel-code-frame": "^6.26.0",
-						"babel-generator": "^6.26.0",
-						"babel-helpers": "^6.24.1",
-						"babel-messages": "^6.23.0",
-						"babel-register": "^6.26.0",
-						"babel-runtime": "^6.26.0",
-						"babel-template": "^6.26.0",
-						"babel-traverse": "^6.26.0",
-						"babel-types": "^6.26.0",
-						"babylon": "^6.18.0",
-						"convert-source-map": "^1.5.1",
-						"debug": "^2.6.9",
-						"json5": "^0.5.1",
-						"lodash": "^4.17.4",
-						"minimatch": "^3.0.4",
-						"path-is-absolute": "^1.0.1",
-						"private": "^0.1.8",
-						"slash": "^1.0.0",
-						"source-map": "^0.5.7"
-					},
-					"dependencies": {
-						"source-map": {
-							"version": "0.5.7",
-							"bundled": true,
-							"dev": true
-						}
-					}
-				},
-				"babel-generator": {
-					"version": "6.26.1",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"babel-messages": "^6.23.0",
-						"babel-runtime": "^6.26.0",
-						"babel-types": "^6.26.0",
-						"detect-indent": "^4.0.0",
-						"jsesc": "^1.3.0",
-						"lodash": "^4.17.4",
-						"source-map": "^0.5.7",
-						"trim-right": "^1.0.1"
-					},
-					"dependencies": {
-						"source-map": {
-							"version": "0.5.7",
-							"bundled": true,
-							"dev": true
-						}
-					}
-				},
-				"babel-helper-builder-react-jsx": {
-					"version": "6.26.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"babel-runtime": "^6.26.0",
-						"babel-types": "^6.26.0",
-						"esutils": "^2.0.2"
-					}
-				},
-				"babel-helpers": {
-					"version": "6.24.1",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"babel-runtime": "^6.22.0",
-						"babel-template": "^6.24.1"
-					}
-				},
-				"babel-messages": {
-					"version": "6.23.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"babel-runtime": "^6.22.0"
-					}
-				},
-				"babel-plugin-syntax-jsx": {
-					"version": "6.18.0",
+					"version": "3.0.0",
 					"bundled": true,
 					"dev": true
-				},
-				"babel-plugin-syntax-object-rest-spread": {
-					"version": "6.13.0",
-					"bundled": true,
-					"dev": true
-				},
-				"babel-plugin-transform-es2015-destructuring": {
-					"version": "6.23.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"babel-runtime": "^6.22.0"
-					}
-				},
-				"babel-plugin-transform-object-rest-spread": {
-					"version": "6.26.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"babel-plugin-syntax-object-rest-spread": "^6.8.0",
-						"babel-runtime": "^6.26.0"
-					}
-				},
-				"babel-plugin-transform-react-jsx": {
-					"version": "6.24.1",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"babel-helper-builder-react-jsx": "^6.24.1",
-						"babel-plugin-syntax-jsx": "^6.8.0",
-						"babel-runtime": "^6.22.0"
-					}
-				},
-				"babel-register": {
-					"version": "6.26.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"babel-core": "^6.26.0",
-						"babel-runtime": "^6.26.0",
-						"core-js": "^2.5.0",
-						"home-or-tmp": "^2.0.0",
-						"lodash": "^4.17.4",
-						"mkdirp": "^0.5.1",
-						"source-map-support": "^0.4.15"
-					},
-					"dependencies": {
-						"source-map": {
-							"version": "0.5.7",
-							"bundled": true,
-							"dev": true
-						},
-						"source-map-support": {
-							"version": "0.4.18",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"source-map": "^0.5.6"
-							}
-						}
-					}
-				},
-				"babel-runtime": {
-					"version": "6.26.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"core-js": "^2.4.0",
-						"regenerator-runtime": "^0.11.0"
-					}
-				},
-				"babel-template": {
-					"version": "6.26.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"babel-runtime": "^6.26.0",
-						"babel-traverse": "^6.26.0",
-						"babel-types": "^6.26.0",
-						"babylon": "^6.18.0",
-						"lodash": "^4.17.4"
-					}
-				},
-				"babel-traverse": {
-					"version": "6.26.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"babel-code-frame": "^6.26.0",
-						"babel-messages": "^6.23.0",
-						"babel-runtime": "^6.26.0",
-						"babel-types": "^6.26.0",
-						"babylon": "^6.18.0",
-						"debug": "^2.6.8",
-						"globals": "^9.18.0",
-						"invariant": "^2.2.2",
-						"lodash": "^4.17.4"
-					}
-				},
-				"babel-types": {
-					"version": "6.26.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"babel-runtime": "^6.26.0",
-						"esutils": "^2.0.2",
-						"lodash": "^4.17.4",
-						"to-fast-properties": "^1.0.3"
-					}
-				},
-				"babylon": {
-					"version": "6.18.0",
-					"bundled": true,
-					"dev": true
-				},
-				"balanced-match": {
-					"version": "1.0.0",
-					"bundled": true,
-					"dev": true
-				},
-				"brace-expansion": {
-					"version": "1.1.11",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"balanced-match": "^1.0.0",
-						"concat-map": "0.0.1"
-					}
 				},
 				"caller-callsite": {
 					"version": "2.0.0",
@@ -3038,15 +3065,36 @@
 					}
 				},
 				"chalk": {
-					"version": "1.1.3",
+					"version": "3.0.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"ansi-styles": "^2.2.1",
-						"escape-string-regexp": "^1.0.2",
-						"has-ansi": "^2.0.0",
-						"strip-ansi": "^3.0.0",
-						"supports-color": "^2.0.0"
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					},
+					"dependencies": {
+						"ansi-styles": {
+							"version": "4.2.0",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"@types/color-name": "^1.1.1",
+								"color-convert": "^2.0.1"
+							}
+						},
+						"color-convert": {
+							"version": "2.0.1",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"color-name": "~1.1.4"
+							}
+						},
+						"color-name": {
+							"version": "1.1.4",
+							"bundled": true,
+							"dev": true
+						}
 					}
 				},
 				"ci-info": {
@@ -3055,20 +3103,20 @@
 					"dev": true
 				},
 				"cli-cursor": {
+					"version": "3.1.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"restore-cursor": "^3.1.0"
+					}
+				},
+				"cli-truncate": {
 					"version": "2.1.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"restore-cursor": "^2.0.0"
-					}
-				},
-				"cli-truncate": {
-					"version": "1.1.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"slice-ansi": "^1.0.0",
-						"string-width": "^2.0.0"
+						"slice-ansi": "^3.0.0",
+						"string-width": "^4.2.0"
 					}
 				},
 				"color-convert": {
@@ -3084,47 +3132,36 @@
 					"bundled": true,
 					"dev": true
 				},
-				"concat-map": {
-					"version": "0.0.1",
-					"bundled": true,
-					"dev": true
-				},
 				"convert-source-map": {
-					"version": "1.6.0",
+					"version": "1.7.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
 						"safe-buffer": "~5.1.1"
+					},
+					"dependencies": {
+						"safe-buffer": {
+							"version": "5.1.2",
+							"bundled": true,
+							"dev": true
+						}
 					}
 				},
-				"core-js": {
-					"version": "2.6.5",
-					"bundled": true,
-					"dev": true
-				},
 				"csstype": {
-					"version": "2.6.5",
+					"version": "2.6.8",
 					"bundled": true,
 					"dev": true
 				},
 				"debug": {
-					"version": "2.6.9",
+					"version": "4.1.1",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"ms": "2.0.0"
-					}
-				},
-				"detect-indent": {
-					"version": "4.0.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"repeating": "^2.0.0"
+						"ms": "^2.1.1"
 					}
 				},
 				"emoji-regex": {
-					"version": "7.0.3",
+					"version": "8.0.0",
 					"bundled": true,
 					"dev": true
 				},
@@ -3139,7 +3176,7 @@
 					"dev": true
 				},
 				"esutils": {
-					"version": "2.0.2",
+					"version": "2.0.3",
 					"bundled": true,
 					"dev": true
 				},
@@ -3149,137 +3186,51 @@
 					"dev": true
 				},
 				"globals": {
-					"version": "9.18.0",
+					"version": "11.12.0",
 					"bundled": true,
 					"dev": true
-				},
-				"has-ansi": {
-					"version": "2.0.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^2.0.0"
-					}
 				},
 				"has-flag": {
 					"version": "3.0.0",
 					"bundled": true,
 					"dev": true
 				},
-				"home-or-tmp": {
-					"version": "2.0.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"os-homedir": "^1.0.0",
-						"os-tmpdir": "^1.0.1"
-					}
-				},
 				"import-jsx": {
-					"version": "2.0.0",
+					"version": "3.0.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"babel-core": "^6.25.0",
-						"babel-plugin-transform-es2015-destructuring": "^6.23.0",
-						"babel-plugin-transform-object-rest-spread": "^6.23.0",
-						"babel-plugin-transform-react-jsx": "^6.24.1",
+						"@babel/core": "^7.5.5",
+						"@babel/plugin-proposal-object-rest-spread": "^7.5.5",
+						"@babel/plugin-transform-destructuring": "^7.5.0",
+						"@babel/plugin-transform-react-jsx": "^7.3.0",
 						"caller-path": "^2.0.0",
 						"resolve-from": "^3.0.0"
 					}
 				},
 				"ink": {
-					"version": "2.3.0",
+					"version": "2.6.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"@types/react": "^16.8.6",
-						"arrify": "^1.0.1",
-						"auto-bind": "^2.0.0",
-						"chalk": "^2.4.1",
-						"cli-cursor": "^2.1.0",
-						"cli-truncate": "^1.1.0",
+						"ansi-escapes": "^4.2.1",
+						"arrify": "^2.0.1",
+						"auto-bind": "^3.0.0",
+						"chalk": "^3.0.0",
+						"cli-cursor": "^3.1.0",
+						"cli-truncate": "^2.0.0",
 						"is-ci": "^2.0.0",
 						"lodash.throttle": "^4.1.1",
 						"log-update": "^3.0.0",
 						"prop-types": "^15.6.2",
-						"react-reconciler": "^0.20.0",
-						"scheduler": "^0.13.2",
+						"react-reconciler": "^0.24.0",
+						"scheduler": "^0.18.0",
 						"signal-exit": "^3.0.2",
-						"slice-ansi": "^1.0.0",
-						"string-length": "^2.0.0",
-						"widest-line": "^2.0.0",
-						"wrap-ansi": "^5.0.0",
+						"slice-ansi": "^3.0.0",
+						"string-length": "^3.1.0",
+						"widest-line": "^3.1.0",
+						"wrap-ansi": "^6.2.0",
 						"yoga-layout-prebuilt": "^1.9.3"
-					},
-					"dependencies": {
-						"ansi-regex": {
-							"version": "4.1.0",
-							"bundled": true,
-							"dev": true
-						},
-						"ansi-styles": {
-							"version": "3.2.1",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"color-convert": "^1.9.0"
-							}
-						},
-						"chalk": {
-							"version": "2.4.2",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"ansi-styles": "^3.2.1",
-								"escape-string-regexp": "^1.0.5",
-								"supports-color": "^5.3.0"
-							}
-						},
-						"string-width": {
-							"version": "3.1.0",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"emoji-regex": "^7.0.1",
-								"is-fullwidth-code-point": "^2.0.0",
-								"strip-ansi": "^5.1.0"
-							}
-						},
-						"strip-ansi": {
-							"version": "5.2.0",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"ansi-regex": "^4.1.0"
-							}
-						},
-						"supports-color": {
-							"version": "5.5.0",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"has-flag": "^3.0.0"
-							}
-						},
-						"wrap-ansi": {
-							"version": "5.1.0",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"ansi-styles": "^3.2.0",
-								"string-width": "^3.0.0",
-								"strip-ansi": "^5.0.0"
-							}
-						}
-					}
-				},
-				"invariant": {
-					"version": "2.2.4",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"loose-envify": "^1.0.0"
 					}
 				},
 				"is-ci": {
@@ -3290,36 +3241,31 @@
 						"ci-info": "^2.0.0"
 					}
 				},
-				"is-finite": {
-					"version": "1.0.2",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"number-is-nan": "^1.0.0"
-					}
-				},
 				"is-fullwidth-code-point": {
-					"version": "2.0.0",
+					"version": "3.0.0",
 					"bundled": true,
 					"dev": true
 				},
 				"js-tokens": {
-					"version": "3.0.2",
+					"version": "4.0.0",
 					"bundled": true,
 					"dev": true
 				},
 				"jsesc": {
-					"version": "1.3.0",
+					"version": "2.5.2",
 					"bundled": true,
 					"dev": true
 				},
 				"json5": {
-					"version": "0.5.1",
+					"version": "2.1.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"requires": {
+						"minimist": "^1.2.0"
+					}
 				},
 				"lodash": {
-					"version": "4.17.14",
+					"version": "4.17.15",
 					"bundled": true,
 					"dev": true
 				},
@@ -3329,7 +3275,7 @@
 					"dev": true
 				},
 				"log-update": {
-					"version": "3.2.0",
+					"version": "3.3.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
@@ -3338,17 +3284,54 @@
 						"wrap-ansi": "^5.0.0"
 					},
 					"dependencies": {
+						"ansi-escapes": {
+							"version": "3.2.0",
+							"bundled": true,
+							"dev": true
+						},
 						"ansi-regex": {
 							"version": "4.1.0",
 							"bundled": true,
 							"dev": true
 						},
-						"ansi-styles": {
-							"version": "3.2.1",
+						"cli-cursor": {
+							"version": "2.1.0",
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"color-convert": "^1.9.0"
+								"restore-cursor": "^2.0.0"
+							}
+						},
+						"emoji-regex": {
+							"version": "7.0.3",
+							"bundled": true,
+							"dev": true
+						},
+						"is-fullwidth-code-point": {
+							"version": "2.0.0",
+							"bundled": true,
+							"dev": true
+						},
+						"mimic-fn": {
+							"version": "1.2.0",
+							"bundled": true,
+							"dev": true
+						},
+						"onetime": {
+							"version": "2.0.1",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"mimic-fn": "^1.0.0"
+							}
+						},
+						"restore-cursor": {
+							"version": "2.0.0",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"onetime": "^2.0.0",
+								"signal-exit": "^3.0.2"
 							}
 						},
 						"string-width": {
@@ -3389,52 +3372,33 @@
 						"js-tokens": "^3.0.0 || ^4.0.0"
 					}
 				},
-				"minimatch": {
-					"version": "3.0.4",
+				"mimic-fn": {
+					"version": "2.1.0",
 					"bundled": true,
-					"dev": true,
-					"requires": {
-						"brace-expansion": "^1.1.7"
-					}
+					"dev": true
+				},
+				"minimist": {
+					"version": "1.2.0",
+					"bundled": true,
+					"dev": true
 				},
 				"minipass": {
-					"version": "2.3.5",
+					"version": "3.1.1",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"safe-buffer": "^5.1.2",
-						"yallist": "^3.0.0"
+						"yallist": "^4.0.0"
 					},
 					"dependencies": {
 						"yallist": {
-							"version": "3.0.3",
-							"bundled": true,
-							"dev": true
-						}
-					}
-				},
-				"mkdirp": {
-					"version": "0.5.1",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"minimist": "0.0.8"
-					},
-					"dependencies": {
-						"minimist": {
-							"version": "0.0.8",
+							"version": "4.0.0",
 							"bundled": true,
 							"dev": true
 						}
 					}
 				},
 				"ms": {
-					"version": "2.0.0",
-					"bundled": true,
-					"dev": true
-				},
-				"number-is-nan": {
-					"version": "1.0.1",
+					"version": "2.1.2",
 					"bundled": true,
 					"dev": true
 				},
@@ -3444,37 +3408,15 @@
 					"dev": true
 				},
 				"onetime": {
-					"version": "2.0.1",
+					"version": "5.1.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"mimic-fn": "^1.0.0"
-					},
-					"dependencies": {
-						"mimic-fn": {
-							"version": "1.2.0",
-							"bundled": true,
-							"dev": true
-						}
+						"mimic-fn": "^2.1.0"
 					}
 				},
-				"os-homedir": {
-					"version": "1.0.2",
-					"bundled": true,
-					"dev": true
-				},
-				"os-tmpdir": {
-					"version": "1.0.2",
-					"bundled": true,
-					"dev": true
-				},
-				"path-is-absolute": {
-					"version": "1.0.1",
-					"bundled": true,
-					"dev": true
-				},
-				"private": {
-					"version": "0.1.8",
+				"path-parse": {
+					"version": "1.0.6",
 					"bundled": true,
 					"dev": true
 				},
@@ -3493,31 +3435,20 @@
 					"bundled": true,
 					"dev": true
 				},
-				"react": {
-					"version": "16.8.6",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"loose-envify": "^1.1.0",
-						"object-assign": "^4.1.1",
-						"prop-types": "^15.6.2",
-						"scheduler": "^0.13.6"
-					}
-				},
 				"react-is": {
-					"version": "16.8.6",
+					"version": "16.12.0",
 					"bundled": true,
 					"dev": true
 				},
 				"react-reconciler": {
-					"version": "0.20.4",
+					"version": "0.24.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
 						"loose-envify": "^1.1.0",
 						"object-assign": "^4.1.1",
 						"prop-types": "^15.6.2",
-						"scheduler": "^0.13.6"
+						"scheduler": "^0.18.0"
 					}
 				},
 				"redeyed": {
@@ -3529,16 +3460,16 @@
 					}
 				},
 				"regenerator-runtime": {
-					"version": "0.11.1",
+					"version": "0.13.3",
 					"bundled": true,
 					"dev": true
 				},
-				"repeating": {
-					"version": "2.0.1",
+				"resolve": {
+					"version": "1.13.1",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"is-finite": "^1.0.0"
+						"path-parse": "^1.0.6"
 					}
 				},
 				"resolve-from": {
@@ -3547,11 +3478,11 @@
 					"dev": true
 				},
 				"restore-cursor": {
-					"version": "2.0.0",
+					"version": "3.1.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"onetime": "^2.0.0",
+						"onetime": "^5.1.0",
 						"signal-exit": "^3.0.2"
 					}
 				},
@@ -3564,13 +3495,8 @@
 						"glob": "^7.1.3"
 					}
 				},
-				"safe-buffer": {
-					"version": "5.1.2",
-					"bundled": true,
-					"dev": true
-				},
 				"scheduler": {
-					"version": "0.13.6",
+					"version": "0.18.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
@@ -3578,92 +3504,119 @@
 						"object-assign": "^4.1.1"
 					}
 				},
+				"semver": {
+					"version": "5.7.1",
+					"bundled": true,
+					"dev": true
+				},
 				"signal-exit": {
 					"version": "3.0.2",
 					"bundled": true,
 					"dev": true
 				},
-				"slash": {
-					"version": "1.0.0",
-					"bundled": true,
-					"dev": true
-				},
 				"slice-ansi": {
-					"version": "1.0.0",
+					"version": "3.0.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"is-fullwidth-code-point": "^2.0.0"
+						"ansi-styles": "^4.0.0",
+						"astral-regex": "^2.0.0",
+						"is-fullwidth-code-point": "^3.0.0"
+					},
+					"dependencies": {
+						"ansi-styles": {
+							"version": "4.2.0",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"@types/color-name": "^1.1.1",
+								"color-convert": "^2.0.1"
+							}
+						},
+						"color-convert": {
+							"version": "2.0.1",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"color-name": "~1.1.4"
+							}
+						},
+						"color-name": {
+							"version": "1.1.4",
+							"bundled": true,
+							"dev": true
+						}
 					}
 				},
 				"string-length": {
-					"version": "2.0.0",
+					"version": "3.1.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
 						"astral-regex": "^1.0.0",
-						"strip-ansi": "^4.0.0"
+						"strip-ansi": "^5.2.0"
 					},
 					"dependencies": {
 						"ansi-regex": {
-							"version": "3.0.0",
+							"version": "4.1.0",
+							"bundled": true,
+							"dev": true
+						},
+						"astral-regex": {
+							"version": "1.0.0",
 							"bundled": true,
 							"dev": true
 						},
 						"strip-ansi": {
-							"version": "4.0.0",
+							"version": "5.2.0",
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"ansi-regex": "^3.0.0"
+								"ansi-regex": "^4.1.0"
 							}
 						}
 					}
 				},
 				"string-width": {
-					"version": "2.1.1",
+					"version": "4.2.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"is-fullwidth-code-point": "^2.0.0",
-						"strip-ansi": "^4.0.0"
-					},
-					"dependencies": {
-						"ansi-regex": {
-							"version": "3.0.0",
-							"bundled": true,
-							"dev": true
-						},
-						"strip-ansi": {
-							"version": "4.0.0",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"ansi-regex": "^3.0.0"
-							}
-						}
+						"emoji-regex": "^8.0.0",
+						"is-fullwidth-code-point": "^3.0.0",
+						"strip-ansi": "^6.0.0"
 					}
 				},
 				"strip-ansi": {
-					"version": "3.0.1",
+					"version": "6.0.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"ansi-regex": "^2.0.0"
+						"ansi-regex": "^5.0.0"
 					}
 				},
 				"supports-color": {
-					"version": "2.0.0",
+					"version": "7.1.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					},
+					"dependencies": {
+						"has-flag": {
+							"version": "4.0.0",
+							"bundled": true,
+							"dev": true
+						}
+					}
 				},
 				"tap-parser": {
-					"version": "9.3.2",
+					"version": "10.0.1",
 					"bundled": true,
 					"dev": true,
 					"requires": {
 						"events-to-array": "^1.0.1",
-						"minipass": "^2.2.0",
+						"minipass": "^3.0.0",
 						"tap-yaml": "^1.0.0"
 					}
 				},
@@ -3676,55 +3629,36 @@
 					}
 				},
 				"to-fast-properties": {
-					"version": "1.0.3",
+					"version": "2.0.0",
 					"bundled": true,
 					"dev": true
 				},
 				"treport": {
-					"version": "0.4.0",
+					"version": "1.0.1",
 					"bundled": true,
 					"dev": true,
 					"requires": {
 						"cardinal": "^2.1.1",
-						"chalk": "^2.4.2",
-						"import-jsx": "^2.0.0",
-						"ink": "^2.1.1",
-						"ms": "^2.1.1",
-						"react": "^16.8.6",
-						"string-length": "^2.0.0",
-						"tap-parser": "^9.3.2",
-						"unicode-length": "^2.0.1"
+						"chalk": "^3.0.0",
+						"import-jsx": "^3.0.0",
+						"ink": "^2.5.0",
+						"ms": "^2.1.2",
+						"string-length": "^3.1.0",
+						"tap-parser": "^10.0.1",
+						"unicode-length": "^2.0.2"
 					},
 					"dependencies": {
-						"ansi-styles": {
-							"version": "3.2.1",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"color-convert": "^1.9.0"
-							}
-						},
-						"chalk": {
-							"version": "2.4.2",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"ansi-styles": "^3.2.1",
-								"escape-string-regexp": "^1.0.5",
-								"supports-color": "^5.3.0"
-							}
-						},
-						"ms": {
-							"version": "2.1.2",
+						"ansi-regex": {
+							"version": "2.1.1",
 							"bundled": true,
 							"dev": true
 						},
-						"supports-color": {
-							"version": "5.5.0",
+						"strip-ansi": {
+							"version": "3.0.1",
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"has-flag": "^3.0.0"
+								"ansi-regex": "^2.0.0"
 							}
 						},
 						"unicode-length": {
@@ -3738,25 +3672,59 @@
 						}
 					}
 				},
-				"trim-right": {
-					"version": "1.0.1",
+				"type-fest": {
+					"version": "0.8.1",
 					"bundled": true,
 					"dev": true
 				},
 				"widest-line": {
-					"version": "2.0.1",
+					"version": "3.1.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"string-width": "^2.1.1"
+						"string-width": "^4.0.0"
+					}
+				},
+				"wrap-ansi": {
+					"version": "6.2.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.0.0",
+						"string-width": "^4.1.0",
+						"strip-ansi": "^6.0.0"
+					},
+					"dependencies": {
+						"ansi-styles": {
+							"version": "4.2.0",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"@types/color-name": "^1.1.1",
+								"color-convert": "^2.0.1"
+							}
+						},
+						"color-convert": {
+							"version": "2.0.1",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"color-name": "~1.1.4"
+							}
+						},
+						"color-name": {
+							"version": "1.1.4",
+							"bundled": true,
+							"dev": true
+						}
 					}
 				},
 				"yaml": {
-					"version": "1.6.0",
+					"version": "1.7.2",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"@babel/runtime": "^7.4.5"
+						"@babel/runtime": "^7.6.3"
 					}
 				},
 				"yoga-layout-prebuilt": {
@@ -3767,54 +3735,38 @@
 			}
 		},
 		"tap-mocha-reporter": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/tap-mocha-reporter/-/tap-mocha-reporter-4.0.1.tgz",
-			"integrity": "sha512-/KfXaaYeSPn8qBi5Be8WSIP3iKV83s2uj2vzImJAXmjNu22kzqZ+1Dv1riYWa53sPCiyo1R1w1jbJrftF8SpcQ==",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/tap-mocha-reporter/-/tap-mocha-reporter-5.0.1.tgz",
+			"integrity": "sha512-1knFWOwd4khx/7uSEnUeaP9IPW3w+sqTgJMhrwah6t46nZ8P25atOKAjSvVDsT67lOPu0nfdOqUwoyKn+3E5pA==",
 			"dev": true,
 			"requires": {
 				"color-support": "^1.1.0",
-				"debug": "^2.1.3",
-				"diff": "^1.3.2",
-				"escape-string-regexp": "^1.0.3",
+				"debug": "^4.1.1",
+				"diff": "^4.0.1",
+				"escape-string-regexp": "^2.0.0",
 				"glob": "^7.0.5",
-				"readable-stream": "^2.1.5",
-				"tap-parser": "^8.0.0",
-				"tap-yaml": "0 || 1",
-				"unicode-length": "^1.0.0"
+				"tap-parser": "^10.0.0",
+				"tap-yaml": "^1.0.0",
+				"unicode-length": "^2.0.2"
 			},
 			"dependencies": {
-				"debug": {
-					"version": "2.6.9",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-					"dev": true,
-					"requires": {
-						"ms": "2.0.0"
-					}
-				},
-				"diff": {
-					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
-					"integrity": "sha1-fyjS657nsVqX79ic5j3P2qPMur8=",
-					"dev": true
-				},
-				"ms": {
+				"escape-string-regexp": {
 					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+					"integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
 					"dev": true
 				}
 			}
 		},
 		"tap-parser": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/tap-parser/-/tap-parser-8.1.0.tgz",
-			"integrity": "sha512-GgOzgDwThYLxhVR83RbS1JUR1TxcT+jfZsrETgPAvFdr12lUOnuvrHOBaUQgpkAp6ZyeW6r2Nwd91t88M0ru3w==",
+			"version": "10.0.1",
+			"resolved": "https://registry.npmjs.org/tap-parser/-/tap-parser-10.0.1.tgz",
+			"integrity": "sha512-qdT15H0DoJIi7zOqVXDn9X0gSM68JjNy1w3VemwTJlDnETjbi6SutnqmBfjDJAwkFS79NJ97gZKqie00ZCGmzg==",
 			"dev": true,
 			"requires": {
 				"events-to-array": "^1.0.1",
-				"minipass": "^2.2.0",
-				"tap-yaml": "0 || 1"
+				"minipass": "^3.0.0",
+				"tap-yaml": "^1.0.0"
 			}
 		},
 		"tap-yaml": {
@@ -3827,10 +3779,13 @@
 			}
 		},
 		"tcompare": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/tcompare/-/tcompare-2.3.0.tgz",
-			"integrity": "sha512-fAfA73uFtFGybWGt4+IYT6UPLYVZQ4NfsP+IXEZGY0vh8e2IF7LVKafcQNMRBLqP0wzEA65LM9Tqj+FSmO8GLw==",
-			"dev": true
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/tcompare/-/tcompare-3.0.4.tgz",
+			"integrity": "sha512-Q3TitMVK59NyKgQyFh+857wTAUE329IzLDehuPgU4nF5e8g+EUQ+yUbjUy1/6ugiNnXztphT+NnqlCXolv9P3A==",
+			"dev": true,
+			"requires": {
+				"diff-frag": "^1.0.1"
+			}
 		},
 		"test-exclude": {
 			"version": "5.2.3",
@@ -3882,12 +3837,6 @@
 			"resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
 			"integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc="
 		},
-		"trim-right": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
-			"integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
-			"dev": true
-		},
 		"trivial-deferred": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/trivial-deferred/-/trivial-deferred-1.0.1.tgz",
@@ -3895,16 +3844,16 @@
 			"dev": true
 		},
 		"ts-node": {
-			"version": "8.3.0",
-			"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.3.0.tgz",
-			"integrity": "sha512-dyNS/RqyVTDcmNM4NIBAeDMpsAdaQ+ojdf0GOLqE6nwJOgzEkdRNzJywhDfwnuvB10oa6NLVG1rUJQCpRN7qoQ==",
+			"version": "8.6.0",
+			"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.6.0.tgz",
+			"integrity": "sha512-NVJ/5ZjrxCS445zMIxGWiieTZoWcHbqtVKa+1V7opSmOFCYi7fvkugEXZBC9IvUnEzNewZWy8dw0u6iSTridpA==",
 			"dev": true,
 			"requires": {
 				"arg": "^4.1.0",
 				"diff": "^4.0.1",
 				"make-error": "^1.1.1",
 				"source-map-support": "^0.5.6",
-				"yn": "^3.0.0"
+				"yn": "^4.0.0"
 			}
 		},
 		"tunnel-agent": {
@@ -3940,19 +3889,19 @@
 			}
 		},
 		"typescript": {
-			"version": "3.6.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.3.tgz",
-			"integrity": "sha512-N7bceJL1CtRQ2RiG0AQME13ksR7DiuQh/QehubYcghzv20tnh+MQnQIuJddTmsbqYj+dztchykemz0zFzlvdQw==",
+			"version": "3.7.4",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.4.tgz",
+			"integrity": "sha512-A25xv5XCtarLwXpcDNZzCGvW2D1S3/bACratYBx2sax8PefsFhlYmkQicKHvpYflFS8if4zne5zT5kpJ7pzuvw==",
 			"dev": true
 		},
 		"uglify-js": {
-			"version": "3.6.0",
-			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.0.tgz",
-			"integrity": "sha512-W+jrUHJr3DXKhrsS7NUVxn3zqMOFn0hL/Ei6v0anCIMoKC93TjcflTagwIHLW7SfMFfiQuktQyFVCFHGUE0+yg==",
+			"version": "3.7.4",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.7.4.tgz",
+			"integrity": "sha512-tinYWE8X1QfCHxS1lBS8yiDekyhSXOO6R66yNOCdUJeojxxw+PX2BHAz/BWyW7PQ7pkiWVxJfIEbiDxyLWvUGg==",
 			"dev": true,
 			"optional": true,
 			"requires": {
-				"commander": "~2.20.0",
+				"commander": "~2.20.3",
 				"source-map": "~0.6.1"
 			}
 		},
@@ -3962,12 +3911,12 @@
 			"integrity": "sha1-a7rwh3UA02vjTsqlhODbn+8DUgk="
 		},
 		"unicode-length": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/unicode-length/-/unicode-length-1.0.3.tgz",
-			"integrity": "sha1-Wtp6f+1RhBpBijKM8UlHisg1irs=",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/unicode-length/-/unicode-length-2.0.2.tgz",
+			"integrity": "sha512-Ph/j1VbS3/r77nhoY2WU0GWGjVYOHL3xpKp0y/Eq2e5r0mT/6b649vm7KFO6RdAdrZkYLdxphYVgvODxPB+Ebg==",
 			"dev": true,
 			"requires": {
-				"punycode": "^1.3.2",
+				"punycode": "^2.0.0",
 				"strip-ansi": "^3.0.1"
 			},
 			"dependencies": {
@@ -3975,6 +3924,12 @@
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
 					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+					"dev": true
+				},
+				"punycode": {
+					"version": "2.1.1",
+					"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+					"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
 					"dev": true
 				},
 				"strip-ansi": {
@@ -4020,9 +3975,9 @@
 			"integrity": "sha1-EWsCVEjJtQAIHN+/H01sbDfYg30="
 		},
 		"utfstring": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/utfstring/-/utfstring-2.0.0.tgz",
-			"integrity": "sha512-/ugBfyvIoLe9xqkFHio3CxXnpUKQ1p2LfTxPr6QTRj6GiwpHo73YGdh03UmAzDQNOWpNIE0J5nLss00L4xlWgg=="
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/utfstring/-/utfstring-2.0.1.tgz",
+			"integrity": "sha512-x8lx0NGB2OUxOOvFE3z4feOpJWrVrllGRzJq4h6H70bh3sincW+LAlexHBFD5jzV9sZ5qcabZcCwA7ZD6MdUkg=="
 		},
 		"util-deprecate": {
 			"version": "1.0.2",
@@ -4077,9 +4032,9 @@
 			"integrity": "sha1-nITsLc9oGH/wC8ZOEnS0QhduHIQ="
 		},
 		"which": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-			"integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
 			"dev": true,
 			"requires": {
 				"isexe": "^2.0.0"
@@ -4096,10 +4051,15 @@
 			"resolved": "https://registry.npmjs.org/word-count/-/word-count-0.2.2.tgz",
 			"integrity": "sha1-aZGS/KaCn+k21Byw2V25JIxXBFE="
 		},
+		"word-wrap": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+			"integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ=="
+		},
 		"wordwrap": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-			"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+			"integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
 		},
 		"wrap-ansi": {
 			"version": "2.1.0",
@@ -4154,9 +4114,9 @@
 			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
 		},
 		"write-file-atomic": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.0.tgz",
-			"integrity": "sha512-EIgkf60l2oWsffja2Sf2AL384dx328c0B+cIYPTQq5q2rOYuDV00/iPFBOUiDKKwKMOhkymH8AidPaRvzfxY+Q==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.1.tgz",
+			"integrity": "sha512-JPStrIyyVJ6oCSz/691fAjFtefZ6q+fP6tm+OS4Qw6o+TGQxNp1ziY2PgS+X/m0V8OWhZiO/m4xSj+Pr4RrZvw==",
 			"dev": true,
 			"requires": {
 				"imurmurhash": "^0.1.4",
@@ -4178,12 +4138,12 @@
 			"dev": true
 		},
 		"yaml": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-1.6.0.tgz",
-			"integrity": "sha512-iZfse3lwrJRoSlfs/9KQ9iIXxs9++RvBFVzAqbbBiFT+giYtyanevreF9r61ZTbGMgWQBxAua3FzJiniiJXWWw==",
+			"version": "1.7.2",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-1.7.2.tgz",
+			"integrity": "sha512-qXROVp90sb83XtAoqE8bP9RwAkTTZbugRUTm5YeFCBfNRPEp2YzTeqWiz7m5OORHzEvrA/qcGS8hp/E+MMROYw==",
 			"dev": true,
 			"requires": {
-				"@babel/runtime": "^7.4.5"
+				"@babel/runtime": "^7.6.3"
 			}
 		},
 		"yamljs": {
@@ -4280,9 +4240,9 @@
 			}
 		},
 		"yn": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-			"integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/yn/-/yn-4.0.0.tgz",
+			"integrity": "sha512-huWiiCS4TxKc4SfgmTwW1K7JmXPPAmuXWYy4j9qjQo4+27Kni8mGhAAi1cloRWmBe2EqcLgt3IGqQoRL/MtPgg==",
 			"dev": true
 		}
 	}

--- a/packages/runtime/package-lock.json
+++ b/packages/runtime/package-lock.json
@@ -14,16 +14,15 @@
 			}
 		},
 		"@babel/generator": {
-			"version": "7.6.0",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.6.0.tgz",
-			"integrity": "sha512-Ms8Mo7YBdMMn1BYuNtKuP/z0TgEIhbcyB8HVR6PPNYp4P61lMsABiS4A3VG1qznjXVCf3r+fVHhm4efTYVsySA==",
+			"version": "7.7.7",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.7.7.tgz",
+			"integrity": "sha512-/AOIBpHh/JU1l0ZFS4kiRCBnLi6OTHzh0RPk3h9isBxkkqELtQNFi1Vr/tiG9p1yfoUdKVwISuXWQR+hwwM4VQ==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.6.0",
+				"@babel/types": "^7.7.4",
 				"jsesc": "^2.5.1",
 				"lodash": "^4.17.13",
-				"source-map": "^0.5.0",
-				"trim-right": "^1.0.1"
+				"source-map": "^0.5.0"
 			},
 			"dependencies": {
 				"source-map": {
@@ -35,32 +34,32 @@
 			}
 		},
 		"@babel/helper-function-name": {
-			"version": "7.1.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.1.0.tgz",
-			"integrity": "sha512-A95XEoCpb3TO+KZzJ4S/5uW5fNe26DjBGqf1o9ucyLyCmi1dXq/B3c8iaWTfBk3VvetUxl16e8tIrd5teOCfGw==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.7.4.tgz",
+			"integrity": "sha512-AnkGIdiBhEuiwdoMnKm7jfPfqItZhgRaZfMg1XX3bS25INOnLPjPG1Ppnajh8eqgt5kPJnfqrRHqFqmjKDZLzQ==",
 			"dev": true,
 			"requires": {
-				"@babel/helper-get-function-arity": "^7.0.0",
-				"@babel/template": "^7.1.0",
-				"@babel/types": "^7.0.0"
+				"@babel/helper-get-function-arity": "^7.7.4",
+				"@babel/template": "^7.7.4",
+				"@babel/types": "^7.7.4"
 			}
 		},
 		"@babel/helper-get-function-arity": {
-			"version": "7.0.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0.tgz",
-			"integrity": "sha512-r2DbJeg4svYvt3HOS74U4eWKsUAMRH01Z1ds1zx8KNTPtpTL5JAsdFv8BNyOpVqdFhHkkRDIg5B4AsxmkjAlmQ==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.7.4.tgz",
+			"integrity": "sha512-QTGKEdCkjgzgfJ3bAyRwF4yyT3pg+vDgan8DSivq1eS0gwi+KGKE5x8kRcbeFTb/673mkO5SN1IZfmCfA5o+EA==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.0.0"
+				"@babel/types": "^7.7.4"
 			}
 		},
 		"@babel/helper-split-export-declaration": {
-			"version": "7.4.4",
-			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.4.4.tgz",
-			"integrity": "sha512-Ro/XkzLf3JFITkW6b+hNxzZ1n5OQ80NvIUdmHspih1XAhtN3vPTuUFT4eQnela+2MaZ5ulH+iyP513KJrxbN7Q==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.7.4.tgz",
+			"integrity": "sha512-guAg1SXFcVr04Guk9eq0S4/rWS++sbmyqosJzVs8+1fH5NI+ZcmkaSkc7dmtAFbHFva6yRJnjW3yAcGxjueDug==",
 			"dev": true,
 			"requires": {
-				"@babel/types": "^7.4.4"
+				"@babel/types": "^7.7.4"
 			}
 		},
 		"@babel/highlight": {
@@ -75,68 +74,52 @@
 			}
 		},
 		"@babel/parser": {
-			"version": "7.5.5",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.5.5.tgz",
-			"integrity": "sha512-E5BN68cqR7dhKan1SfqgPGhQ178bkVKpXTPEXnFJBrEt8/DKRZlybmy+IgYLTeN7tp1R5Ccmbm2rBk17sHYU3g==",
+			"version": "7.7.7",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.7.tgz",
+			"integrity": "sha512-WtTZMZAZLbeymhkd/sEaPD8IQyGAhmuTuvTzLiCFM7iXiVdY0gc0IaI+cW0fh1BnSMbJSzXX6/fHllgHKwHhXw==",
 			"dev": true
 		},
 		"@babel/runtime": {
-			"version": "7.6.0",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.6.0.tgz",
-			"integrity": "sha512-89eSBLJsxNxOERC0Op4vd+0Bqm6wRMqMbFtV3i0/fbaWw/mJ8Q3eBvgX0G4SyrOOLCtbu98HspF8o09MRT+KzQ==",
+			"version": "7.7.7",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.7.tgz",
+			"integrity": "sha512-uCnC2JEVAu8AKB5do1WRIsvrdJ0flYx/A/9f/6chdacnEZ7LmavjdsDXr5ksYBegxtuTPR5Va9/+13QF/kFkCA==",
 			"dev": true,
 			"requires": {
 				"regenerator-runtime": "^0.13.2"
 			}
 		},
 		"@babel/template": {
-			"version": "7.6.0",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.6.0.tgz",
-			"integrity": "sha512-5AEH2EXD8euCk446b7edmgFdub/qfH1SN6Nii3+fyXP807QRx9Q73A2N5hNwRRslC2H9sNzaFhsPubkS4L8oNQ==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.7.4.tgz",
+			"integrity": "sha512-qUzihgVPguAzXCK7WXw8pqs6cEwi54s3E+HrejlkuWO6ivMKx9hZl3Y2fSXp9i5HgyWmj7RKP+ulaYnKM4yYxw==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.0.0",
-				"@babel/parser": "^7.6.0",
-				"@babel/types": "^7.6.0"
-			},
-			"dependencies": {
-				"@babel/parser": {
-					"version": "7.6.0",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.6.0.tgz",
-					"integrity": "sha512-+o2q111WEx4srBs7L9eJmcwi655eD8sXniLqMB93TBK9GrNzGrxDWSjiqz2hLU0Ha8MTXFIP0yd9fNdP+m43ZQ==",
-					"dev": true
-				}
+				"@babel/parser": "^7.7.4",
+				"@babel/types": "^7.7.4"
 			}
 		},
 		"@babel/traverse": {
-			"version": "7.6.0",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.6.0.tgz",
-			"integrity": "sha512-93t52SaOBgml/xY74lsmt7xOR4ufYvhb5c5qiM6lu4J/dWGMAfAh6eKw4PjLes6DI6nQgearoxnFJk60YchpvQ==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.7.4.tgz",
+			"integrity": "sha512-P1L58hQyupn8+ezVA2z5KBm4/Zr4lCC8dwKCMYzsa5jFMDMQAzaBNy9W5VjB+KAmBjb40U7a/H6ao+Xo+9saIw==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.5.5",
-				"@babel/generator": "^7.6.0",
-				"@babel/helper-function-name": "^7.1.0",
-				"@babel/helper-split-export-declaration": "^7.4.4",
-				"@babel/parser": "^7.6.0",
-				"@babel/types": "^7.6.0",
+				"@babel/generator": "^7.7.4",
+				"@babel/helper-function-name": "^7.7.4",
+				"@babel/helper-split-export-declaration": "^7.7.4",
+				"@babel/parser": "^7.7.4",
+				"@babel/types": "^7.7.4",
 				"debug": "^4.1.0",
 				"globals": "^11.1.0",
 				"lodash": "^4.17.13"
-			},
-			"dependencies": {
-				"@babel/parser": {
-					"version": "7.6.0",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.6.0.tgz",
-					"integrity": "sha512-+o2q111WEx4srBs7L9eJmcwi655eD8sXniLqMB93TBK9GrNzGrxDWSjiqz2hLU0Ha8MTXFIP0yd9fNdP+m43ZQ==",
-					"dev": true
-				}
 			}
 		},
 		"@babel/types": {
-			"version": "7.6.1",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.6.1.tgz",
-			"integrity": "sha512-X7gdiuaCmA0uRjCmRtYJNAVCc/q+5xSgsfKJHqMN4iNLILX39677fJE1O40arPMh0TTtS9ItH67yre6c7k6t0g==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.4.tgz",
+			"integrity": "sha512-cz5Ji23KCi4T+YIE/BolWosrJuSmoZeN1EFnRtBwF+KKLi8GG/Z2c2hOJJeCXPk4mwk4QFvTmwIodJowXgttRA==",
 			"dev": true,
 			"requires": {
 				"esutils": "^2.0.2",
@@ -145,9 +128,9 @@
 			}
 		},
 		"@types/cldrjs": {
-			"version": "0.4.20",
-			"resolved": "https://registry.npmjs.org/@types/cldrjs/-/cldrjs-0.4.20.tgz",
-			"integrity": "sha512-vQe6BQF9QCHSLUlNjRa/1zicRCnQnTRwhW/FqgVv26A85COY1jfkkO6JjogDv22U3LRhu9pY4uPQOlxGnsuJPA==",
+			"version": "0.4.22",
+			"resolved": "https://registry.npmjs.org/@types/cldrjs/-/cldrjs-0.4.22.tgz",
+			"integrity": "sha512-YyzxXZ5s9xwPWznXnI3++X14JGnomDdDAlin7kWZvxX/MzirC9BNFcDSQ0yR8YG2M/xNMn0nXsCGkgbFVyXjGw==",
 			"dev": true
 		},
 		"@types/debug": {
@@ -166,9 +149,9 @@
 			}
 		},
 		"@types/lodash": {
-			"version": "4.14.138",
-			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.138.tgz",
-			"integrity": "sha512-A4uJgHz4hakwNBdHNPdxOTkYmXNgmUAKLbXZ7PKGslgeV0Mb8P3BlbYfPovExek1qnod4pDfRbxuzcVs3dlFLg==",
+			"version": "4.14.149",
+			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.149.tgz",
+			"integrity": "sha512-ijGqzZt/b7BfzcK9vTrS6MFljQRPn5BFWOx8oE0GYxribu6uV+aA9zZuXI1zc/etK9E8nrgdoF2+LgUw7+9tJQ==",
 			"dev": true
 		},
 		"@types/md5": {
@@ -190,9 +173,9 @@
 			}
 		},
 		"@types/node": {
-			"version": "12.7.5",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.5.tgz",
-			"integrity": "sha512-9fq4jZVhPNW8r+UYKnxF1e2HkDWOWKM5bC2/7c9wPV835I0aOrVbS/Hw/pWPk2uKrNXQqg9Z959Kz+IYDd5p3w==",
+			"version": "12.12.24",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.24.tgz",
+			"integrity": "sha512-1Ciqv9pqwVtW6FsIUKSZNB82E5Cu1I2bBTj1xuIHXLe/1zYLl3956Nbhg2MzSYHVfl9/rmanjbQIb7LibfCnug==",
 			"dev": true
 		},
 		"@types/yamljs": {
@@ -238,9 +221,9 @@
 			}
 		},
 		"anymatch": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.0.tgz",
-			"integrity": "sha512-Ozz7l4ixzI7Oxj2+cw+p0tVUt27BpaJ+1+q1TCeANWxHpvyn2+Un+YamBdfKu0uh8xLodGhoa1v7595NhKDAuA==",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.1.tgz",
+			"integrity": "sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==",
 			"dev": true,
 			"requires": {
 				"normalize-path": "^3.0.0",
@@ -263,9 +246,9 @@
 			"dev": true
 		},
 		"arg": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/arg/-/arg-4.1.1.tgz",
-			"integrity": "sha512-SlmP3fEA88MBv0PypnXZ8ZfJhwmDeIE3SP71j37AiXQBXYosPV0x6uISAaHYSlSVhmHOVkomen0tbGk6Anlebw==",
+			"version": "4.1.2",
+			"resolved": "https://registry.npmjs.org/arg/-/arg-4.1.2.tgz",
+			"integrity": "sha512-+ytCkGcBtHZ3V2r2Z06AncYO8jz46UEamcspGoU8lHcEbpn6J77QK0vdWvChsclg/tM5XIJC5tnjmPp7Eq6Obg==",
 			"dev": true
 		},
 		"argparse": {
@@ -298,9 +281,9 @@
 			"dev": true
 		},
 		"async-hook-domain": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/async-hook-domain/-/async-hook-domain-1.1.0.tgz",
-			"integrity": "sha512-NH7V97d1yCbIanu2oDLyPT2GFNct0esPeJyRfkk8J5hTztHVSQp4UiNfL2O42sCA9XZPU8OgHvzOmt9ewBhVqA==",
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/async-hook-domain/-/async-hook-domain-1.1.3.tgz",
+			"integrity": "sha512-ZovMxSbADV3+biB7oR1GL5lGyptI24alp0LWHlmz1OFc5oL47pz3EiIF6nXOkDW7yLqih4NtsiYduzdDW0i+Wg==",
 			"dev": true,
 			"requires": {
 				"source-map-support": "^0.5.11"
@@ -319,9 +302,9 @@
 			"dev": true
 		},
 		"aws4": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
-			"integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.0.tgz",
+			"integrity": "sha512-Uvq6hVe90D0B2WEnUqtdgY1bATGz3mw33nH9Y+dmA+w5DHvUmBgkr5rM/KCHpCsiFNRUfokW/szpPPgMK2hm4A==",
 			"dev": true
 		},
 		"balanced-match": {
@@ -416,12 +399,6 @@
 			"integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
 			"dev": true
 		},
-		"capture-stack-trace": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.1.tgz",
-			"integrity": "sha512-mYQLZnx5Qt1JgB1WEiMCf2647plpGeQ2NMR/5L0HNZzGQo4fuSPnK+wjfPnKZV0aiJDgzmWqqkV/g7JD+DW0qw==",
-			"dev": true
-		},
 		"caseless": {
 			"version": "0.12.0",
 			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
@@ -445,19 +422,19 @@
 			"integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc="
 		},
 		"chokidar": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.0.2.tgz",
-			"integrity": "sha512-c4PR2egjNjI1um6bamCQ6bUNPDiyofNQruHvKgHQ4gDUP/ITSVSzNsiI5OWtHOsX323i5ha/kk4YmOZ1Ktg7KA==",
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.3.1.tgz",
+			"integrity": "sha512-4QYCEWOcK3OJrxwvyyAOxFuhpvOVCYkr33LPfFNBjAD/w3sEzWsp2BUOkI4l9bHvWioAd0rc6NlHUOEaWkTeqg==",
 			"dev": true,
 			"requires": {
-				"anymatch": "^3.0.1",
-				"braces": "^3.0.2",
-				"fsevents": "^2.0.6",
-				"glob-parent": "^5.0.0",
-				"is-binary-path": "^2.1.0",
-				"is-glob": "^4.0.1",
-				"normalize-path": "^3.0.0",
-				"readdirp": "^3.1.1"
+				"anymatch": "~3.1.1",
+				"braces": "~3.0.2",
+				"fsevents": "~2.1.2",
+				"glob-parent": "~5.1.0",
+				"is-binary-path": "~2.1.0",
+				"is-glob": "~4.0.1",
+				"normalize-path": "~3.0.0",
+				"readdirp": "~3.3.0"
 			}
 		},
 		"cldrjs": {
@@ -513,9 +490,9 @@
 			}
 		},
 		"commander": {
-			"version": "2.20.0",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
-			"integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
+			"version": "2.20.3",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
 			"dev": true,
 			"optional": true
 		},
@@ -531,9 +508,9 @@
 			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
 		},
 		"convert-source-map": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.6.0.tgz",
-			"integrity": "sha512-eFu7XigvxdZ1ETfbgPBohgyQ/Z++C0eEhTor0qRwBw9unw+L0/6V8wkSuGgzdThkiS5lSpdptOQPD8Ak40a+7A==",
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
+			"integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
 			"dev": true,
 			"requires": {
 				"safe-buffer": "~5.1.1"
@@ -554,17 +531,16 @@
 			"dev": true
 		},
 		"coveralls": {
-			"version": "3.0.6",
-			"resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.0.6.tgz",
-			"integrity": "sha512-Pgh4v3gCI4T/9VijVrm8Ym5v0OgjvGLKj3zTUwkvsCiwqae/p6VLzpsFNjQS2i6ewV7ef+DjFJ5TSKxYt/mCrA==",
+			"version": "3.0.9",
+			"resolved": "https://registry.npmjs.org/coveralls/-/coveralls-3.0.9.tgz",
+			"integrity": "sha512-nNBg3B1+4iDox5A5zqHKzUTiwl2ey4k2o0NEcVZYvl+GOSJdKBj4AJGKLv6h3SvWch7tABHePAQOSZWM9E2hMg==",
 			"dev": true,
 			"requires": {
-				"growl": "~> 1.10.0",
 				"js-yaml": "^3.13.1",
-				"lcov-parse": "^0.0.10",
+				"lcov-parse": "^1.0.0",
 				"log-driver": "^1.2.7",
 				"minimist": "^1.2.0",
-				"request": "^2.86.0"
+				"request": "^2.88.0"
 			},
 			"dependencies": {
 				"minimist": {
@@ -649,6 +625,12 @@
 			"integrity": "sha512-s2+XdvhPCOF01LRQBC8hf4vhbVmI2CGS5aZnxLJlT5FtdhPCDFq80q++zK2KlrVorVDdL5BOGZ/VfLrVtYNF+Q==",
 			"dev": true
 		},
+		"diff-frag": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/diff-frag/-/diff-frag-1.0.1.tgz",
+			"integrity": "sha512-6/v2PC/6UTGcWPPetb9acL8foberUg/CtPdALeJUdD1B/weHNvzftoo00gYznqHGRhHEbykUGzqfG9RWOSr5yw==",
+			"dev": true
+		},
 		"ecc-jsbn": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
@@ -666,9 +648,9 @@
 			"dev": true
 		},
 		"end-of-stream": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
-			"integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+			"version": "1.4.4",
+			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+			"integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
 			"requires": {
 				"once": "^1.4.0"
 			}
@@ -751,9 +733,9 @@
 			"dev": true
 		},
 		"fast-json-stable-stringify": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-			"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
 			"dev": true
 		},
 		"fill-range": {
@@ -792,18 +774,18 @@
 			"dev": true
 		},
 		"flow-parser": {
-			"version": "0.107.0",
-			"resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.107.0.tgz",
-			"integrity": "sha512-GtMCS8qzP0VskiE5qfN4zYiwjnClV/BxPZ4zUqMRUfyaF+gBuLHDTPqVLJ4ndGedrdv54510rsXDSbkCqUig+g==",
+			"version": "0.115.0",
+			"resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.115.0.tgz",
+			"integrity": "sha512-iasokPUPxp4ojhMaxN215jgp9VFliai+2YVLW3gXN5Yhb/t+QC7Z/CaKBwrrWqainfnl9SH+gr3mSGoq+IXWLQ==",
 			"dev": true
 		},
 		"flow-remove-types": {
-			"version": "2.107.0",
-			"resolved": "https://registry.npmjs.org/flow-remove-types/-/flow-remove-types-2.107.0.tgz",
-			"integrity": "sha512-PXsYEHt5gKuFxw4rSc5e0K2OxhR7JxploCQ4wQzu7wE/Fw42oOs7sdGHPZujTeBY/g3OYSoZ11YxK3KoTHIYWw==",
+			"version": "2.115.0",
+			"resolved": "https://registry.npmjs.org/flow-remove-types/-/flow-remove-types-2.115.0.tgz",
+			"integrity": "sha512-7yf0sQEV/KwXnt/Zs0D40eJORIMQLNztTUBGqb5GvOIIiOStcw8y/yi03Jw0VOwiI7GVqFoONtsCVawQvCrteg==",
 			"dev": true,
 			"requires": {
-				"flow-parser": "^0.107.0",
+				"flow-parser": "^0.115.0",
 				"pirates": "^3.0.2",
 				"vlq": "^0.2.1"
 			}
@@ -859,9 +841,9 @@
 			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
 		},
 		"fsevents": {
-			"version": "2.0.7",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.0.7.tgz",
-			"integrity": "sha512-a7YT0SV3RB+DjYcppwVDLtn13UQnmg0SWZS7ezZD0UjnLwXmy8Zm21GMVGLaFGimIqcvyMQaOJBrop8MyOp1kQ==",
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.2.tgz",
+			"integrity": "sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA==",
 			"dev": true,
 			"optional": true
 		},
@@ -895,9 +877,9 @@
 			}
 		},
 		"glob": {
-			"version": "7.1.4",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
-			"integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+			"version": "7.1.6",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+			"integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
 			"requires": {
 				"fs.realpath": "^1.0.0",
 				"inflight": "^1.0.4",
@@ -908,9 +890,9 @@
 			}
 		},
 		"glob-parent": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.0.0.tgz",
-			"integrity": "sha512-Z2RwiujPRGluePM6j699ktJYxmPpJKCfpGA13jz2hmFZC7gKetzrWvg5KN3+OsIFmydGyZ1AVwERCq1w/ZZwRg==",
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.0.tgz",
+			"integrity": "sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==",
 			"dev": true,
 			"requires": {
 				"is-glob": "^4.0.1"
@@ -931,21 +913,15 @@
 			"dev": true
 		},
 		"graceful-fs": {
-			"version": "4.2.2",
-			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.2.tgz",
-			"integrity": "sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q==",
-			"dev": true
-		},
-		"growl": {
-			"version": "1.10.5",
-			"resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
-			"integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
+			"version": "4.2.3",
+			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
+			"integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
 			"dev": true
 		},
 		"handlebars": {
-			"version": "4.2.0",
-			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.2.0.tgz",
-			"integrity": "sha512-Kb4xn5Qh1cxAKvQnzNWZ512DhABzyFNmsaJf3OAkWNa4NkaqWcNI8Tao8Tasi0/F4JD9oyG0YxuFyvyR57d+Gw==",
+			"version": "4.6.0",
+			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.6.0.tgz",
+			"integrity": "sha512-i1ZUP7Qp2JdkMaFon2a+b0m5geE8Z4ZTLaGkgrObkEd+OkUKyRbRWw4KxuFCoHfdETSY1yf9/574eVoNSiK7pw==",
 			"dev": true,
 			"requires": {
 				"neo-async": "^2.6.0",
@@ -986,9 +962,9 @@
 			}
 		},
 		"hosted-git-info": {
-			"version": "2.8.4",
-			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.4.tgz",
-			"integrity": "sha512-pzXIvANXEFrc5oFFXRMkbLPQ2rXRoDERwDLyrcUxGhaZhgP54BBSl9Oheh7Vv0T090cszWBxPjkQQ5Sq1PbBRQ==",
+			"version": "2.8.5",
+			"resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.5.tgz",
+			"integrity": "sha512-kssjab8CvdXfcXMXVcvsXum4Hwdq9XGtRD3TteMEvEbq0LXyiNQr6AprqKqfeaDXze7SxWvRxdpwE6ku7ikLkg==",
 			"dev": true
 		},
 		"http-signature": {
@@ -1099,13 +1075,6 @@
 			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
 			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
 			"dev": true
-		},
-		"isarray": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-			"dev": true,
-			"optional": true
 		},
 		"isexe": {
 			"version": "2.0.0",
@@ -1309,17 +1278,17 @@
 			}
 		},
 		"lcid": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/lcid/-/lcid-3.0.0.tgz",
-			"integrity": "sha512-cT68NXBqcByQPcYCoMArX8SI5SuzOTjF7nibqHlf24K01zYbFifLHaacZi8Ye3dvmBP9XaatbRO8uXM6YPHlSg==",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/lcid/-/lcid-3.1.1.tgz",
+			"integrity": "sha512-M6T051+5QCGLBQb8id3hdvIW8+zeFV2FyBGFS9IEK5H9Wt4MueD4bW1eWikpHgZp+5xR3l5c8pZUkQsIA0BFZg==",
 			"requires": {
 				"invert-kv": "^3.0.0"
 			}
 		},
 		"lcov-parse": {
-			"version": "0.0.10",
-			"resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-0.0.10.tgz",
-			"integrity": "sha1-GwuP+ayceIklBYK3C3ExXZ2m2aM=",
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/lcov-parse/-/lcov-parse-1.0.0.tgz",
+			"integrity": "sha1-6w1GtUER68VhrLTECO+TY73I9+A=",
 			"dev": true
 		},
 		"load-json-file": {
@@ -1421,6 +1390,15 @@
 			"integrity": "sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg==",
 			"dev": true
 		},
+		"loose-envify": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+			"integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+			"dev": true,
+			"requires": {
+				"js-tokens": "^3.0.0 || ^4.0.0"
+			}
+		},
 		"lru-cache": {
 			"version": "4.1.5",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
@@ -1485,18 +1463,18 @@
 			}
 		},
 		"mime-db": {
-			"version": "1.40.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
-			"integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA==",
+			"version": "1.43.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.43.0.tgz",
+			"integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ==",
 			"dev": true
 		},
 		"mime-types": {
-			"version": "2.1.24",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
-			"integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
+			"version": "2.1.26",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.26.tgz",
+			"integrity": "sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==",
 			"dev": true,
 			"requires": {
-				"mime-db": "1.40.0"
+				"mime-db": "1.43.0"
 			}
 		},
 		"mimic-fn": {
@@ -1518,19 +1496,18 @@
 			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
 		},
 		"minipass": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-2.5.1.tgz",
-			"integrity": "sha512-dmpSnLJtNQioZFI5HfQ55Ad0DzzsMAb+HfokwRTNXwEQjepbTkl5mtIlSVxGIkOkxlpX7wIn5ET/oAd9fZ/Y/Q==",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.1.tgz",
+			"integrity": "sha512-UFqVihv6PQgwj8/yTGvl9kPz7xIAY+R5z6XYjRInD3Gk3qx6QGSD6zEcpeG4Dy/lQnv1J6zv8ejV90hyYIKf3w==",
 			"dev": true,
 			"requires": {
-				"safe-buffer": "^5.1.2",
-				"yallist": "^3.0.0"
+				"yallist": "^4.0.0"
 			},
 			"dependencies": {
 				"yallist": {
-					"version": "3.0.3",
-					"resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
-					"integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
 					"dev": true
 				}
 			}
@@ -1670,6 +1647,12 @@
 			"integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
 			"dev": true
 		},
+		"object-assign": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+			"dev": true
+		},
 		"once": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -1741,9 +1724,9 @@
 			"integrity": "sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg=="
 		},
 		"p-limit": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
-			"integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
+			"integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
 			"dev": true,
 			"requires": {
 				"p-try": "^2.0.0"
@@ -1832,9 +1815,9 @@
 			"dev": true
 		},
 		"picomatch": {
-			"version": "2.0.7",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.0.7.tgz",
-			"integrity": "sha512-oLHIdio3tZ0qH76NybpeneBhYVj0QFTfXEFTc/B3zKQspYfYYkWYgFsmzo+4kvId/bQRcNkVeguI3y+CD22BtA==",
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.1.tgz",
+			"integrity": "sha512-ISBaA8xQNmwELC7eOjqFKMESB2VIqt4PPDD0nsS95b/9dZXvVKOlz9keMSnoGGKcOHXfTvDD6WMaRoSc9UuhRA==",
 			"dev": true
 		},
 		"pify": {
@@ -1862,17 +1845,21 @@
 			}
 		},
 		"prettier": {
-			"version": "1.18.2",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-1.18.2.tgz",
-			"integrity": "sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==",
+			"version": "1.19.1",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
+			"integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
 			"dev": true
 		},
-		"process-nextick-args": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+		"prop-types": {
+			"version": "15.7.2",
+			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+			"integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
 			"dev": true,
-			"optional": true
+			"requires": {
+				"loose-envify": "^1.4.0",
+				"object-assign": "^4.1.1",
+				"react-is": "^16.8.1"
+			}
 		},
 		"pseudomap": {
 			"version": "1.0.2",
@@ -1881,9 +1868,9 @@
 			"dev": true
 		},
 		"psl": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/psl/-/psl-1.4.0.tgz",
-			"integrity": "sha512-HZzqCGPecFLyoRj5HLfuDSKYTJkAfB5thKBIkRHtGjWwY7p1dAyveIbXIq4tO0KYfDF2tHqPUgY9SDnGm00uFw==",
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/psl/-/psl-1.7.0.tgz",
+			"integrity": "sha512-5NsSEDv8zY70ScRnOTn7bK7eanl2MvFrOrS/R6x+dBt5g1ghnj9Zv90kO8GwT8gxcu2ANyFprnFYB85IogIJOQ==",
 			"dev": true
 		},
 		"pump": {
@@ -1907,6 +1894,23 @@
 			"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
 			"dev": true
 		},
+		"react": {
+			"version": "16.12.0",
+			"resolved": "https://registry.npmjs.org/react/-/react-16.12.0.tgz",
+			"integrity": "sha512-fglqy3k5E+81pA8s+7K0/T3DBCF0ZDOher1elBFzF7O6arXJgzyu/FW+COxFvAWXJoJN9KIZbT2LXlukwphYTA==",
+			"dev": true,
+			"requires": {
+				"loose-envify": "^1.1.0",
+				"object-assign": "^4.1.1",
+				"prop-types": "^15.6.2"
+			}
+		},
+		"react-is": {
+			"version": "16.12.0",
+			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.12.0.tgz",
+			"integrity": "sha512-rPCkf/mWBtKc97aLL9/txD8DZdemK0vkA3JMLShjlJB3Pj3s+lpf1KaBzMfQrAmhMQB0n1cU/SUGgKKBCe837Q==",
+			"dev": true
+		},
 		"read-pkg": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
@@ -1928,38 +1932,13 @@
 				"read-pkg": "^3.0.0"
 			}
 		},
-		"readable-stream": {
-			"version": "2.3.6",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-			"integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-			"dev": true,
-			"optional": true,
-			"requires": {
-				"core-util-is": "~1.0.0",
-				"inherits": "~2.0.3",
-				"isarray": "~1.0.0",
-				"process-nextick-args": "~2.0.0",
-				"safe-buffer": "~5.1.1",
-				"string_decoder": "~1.1.1",
-				"util-deprecate": "~1.0.1"
-			},
-			"dependencies": {
-				"safe-buffer": {
-					"version": "5.1.2",
-					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-					"dev": true,
-					"optional": true
-				}
-			}
-		},
 		"readdirp": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.1.2.tgz",
-			"integrity": "sha512-8rhl0xs2cxfVsqzreYCvs8EwBfn/DhVdqtoLmw19uI3SC5avYX9teCurlErfpPXGmYtMHReGaP2RsLnFvz/lnw==",
+			"version": "3.3.0",
+			"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.3.0.tgz",
+			"integrity": "sha512-zz0pAkSPOXXm1viEwygWIPSPkcBYjW1xU5j/JBh5t9bGCJwa6f9+BJa6VaB2g+b55yVrmXzqkyLf4xaWYM0IkQ==",
 			"dev": true,
 			"requires": {
-				"picomatch": "^2.0.4"
+				"picomatch": "^2.0.7"
 			}
 		},
 		"rechoir": {
@@ -2027,9 +2006,9 @@
 			"dev": true
 		},
 		"resolve": {
-			"version": "1.11.1",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.1.tgz",
-			"integrity": "sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==",
+			"version": "1.14.2",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.14.2.tgz",
+			"integrity": "sha512-EjlOBLBO1kxsUxsKjLt7TAECyKW6fOh1VRkykQkKGzcBbjjPIxBqGh0jf7GJ3k/f5mxMqW3htMD3WdTUVtW8HQ==",
 			"dev": true,
 			"requires": {
 				"path-parse": "^1.0.6"
@@ -2063,9 +2042,9 @@
 			"dev": true
 		},
 		"semver": {
-			"version": "5.7.0",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
-			"integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA=="
+			"version": "5.7.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+			"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
 		},
 		"set-blocking": {
 			"version": "2.0.0",
@@ -2109,9 +2088,9 @@
 			"dev": true
 		},
 		"source-map-support": {
-			"version": "0.5.13",
-			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
-			"integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
+			"version": "0.5.16",
+			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.16.tgz",
+			"integrity": "sha512-efyLRJDr68D9hBBNIPWFjhpFzURh+KJykQwvMyW5UiZzYwoF6l4YMMDIJJEyFWxWCqfyxLzz6tSfUFR+kXXsVQ==",
 			"dev": true,
 			"requires": {
 				"buffer-from": "^1.0.0",
@@ -2218,25 +2197,6 @@
 				"strip-ansi": "^4.0.0"
 			}
 		},
-		"string_decoder": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-			"dev": true,
-			"optional": true,
-			"requires": {
-				"safe-buffer": "~5.1.0"
-			},
-			"dependencies": {
-				"safe-buffer": {
-					"version": "5.1.2",
-					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-					"dev": true,
-					"optional": true
-				}
-			}
-		},
 		"strip-ansi": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
@@ -2267,78 +2227,294 @@
 			}
 		},
 		"tap": {
-			"version": "14.6.2",
-			"resolved": "https://registry.npmjs.org/tap/-/tap-14.6.2.tgz",
-			"integrity": "sha512-vGtyUcTXsmqKCv1Cn+noln3Qz3UucIA/1jO3oKR1UDHOC928+HWTmxJt7VkSyXk+ZYoltqVOYTW0BI4iMipzjw==",
+			"version": "14.10.5",
+			"resolved": "https://registry.npmjs.org/tap/-/tap-14.10.5.tgz",
+			"integrity": "sha512-8I8zMFEVu7e7RVcjK1GUNf1vW+6B9TRCZWGgif5siMBfvwTE9/EPN/7aH6W2r+WR2H2YHXcrCJ3XhRitYEVKfQ==",
 			"dev": true,
 			"requires": {
-				"async-hook-domain": "^1.1.0",
+				"@types/react": "^16.9.16",
+				"async-hook-domain": "^1.1.3",
 				"bind-obj-methods": "^2.0.0",
 				"browser-process-hrtime": "^1.0.0",
-				"capture-stack-trace": "^1.0.0",
-				"chokidar": "^3.0.2",
+				"chokidar": "^3.3.0",
 				"color-support": "^1.1.0",
-				"coveralls": "^3.0.5",
+				"coveralls": "^3.0.8",
 				"diff": "^4.0.1",
 				"esm": "^3.2.25",
 				"findit": "^2.0.0",
-				"flow-remove-types": "^2.101.0",
+				"flow-remove-types": "^2.112.0",
 				"foreground-child": "^1.3.3",
 				"fs-exists-cached": "^1.0.0",
 				"function-loop": "^1.0.2",
-				"glob": "^7.1.4",
-				"import-jsx": "^2.0.0",
-				"ink": "^2.3.0",
+				"glob": "^7.1.6",
+				"import-jsx": "^3.0.0",
+				"ink": "^2.5.0",
 				"isexe": "^2.0.0",
 				"istanbul-lib-processinfo": "^1.0.0",
 				"jackspeak": "^1.4.0",
-				"minipass": "^2.3.5",
+				"minipass": "^3.1.1",
 				"mkdirp": "^0.5.1",
 				"nyc": "^14.1.1",
 				"opener": "^1.5.1",
 				"own-or": "^1.0.0",
 				"own-or-env": "^1.0.1",
-				"react": "^16.8.6",
-				"rimraf": "^2.6.3",
+				"react": "^16.12.0",
+				"rimraf": "^2.7.1",
 				"signal-exit": "^3.0.0",
-				"source-map-support": "^0.5.12",
+				"source-map-support": "^0.5.16",
 				"stack-utils": "^1.0.2",
-				"tap-mocha-reporter": "^4.0.1",
-				"tap-parser": "^9.3.2",
+				"tap-mocha-reporter": "^5.0.0",
+				"tap-parser": "^10.0.1",
 				"tap-yaml": "^1.0.0",
-				"tcompare": "^2.3.0",
-				"treport": "^0.4.0",
+				"tcompare": "^3.0.0",
+				"treport": "^1.0.1",
 				"trivial-deferred": "^1.0.1",
-				"ts-node": "^8.3.0",
-				"typescript": "^3.5.3",
-				"which": "^1.3.1",
-				"write-file-atomic": "^3.0.0",
-				"yaml": "^1.6.0",
+				"ts-node": "^8.5.2",
+				"typescript": "^3.7.2",
+				"which": "^2.0.2",
+				"write-file-atomic": "^3.0.1",
+				"yaml": "^1.7.2",
 				"yapool": "^1.0.0"
 			},
 			"dependencies": {
-				"@babel/runtime": {
-					"version": "7.4.5",
+				"@babel/code-frame": {
+					"version": "7.5.5",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"regenerator-runtime": "^0.13.2"
+						"@babel/highlight": "^7.0.0"
+					}
+				},
+				"@babel/core": {
+					"version": "7.7.5",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.5.5",
+						"@babel/generator": "^7.7.4",
+						"@babel/helpers": "^7.7.4",
+						"@babel/parser": "^7.7.5",
+						"@babel/template": "^7.7.4",
+						"@babel/traverse": "^7.7.4",
+						"@babel/types": "^7.7.4",
+						"convert-source-map": "^1.7.0",
+						"debug": "^4.1.0",
+						"json5": "^2.1.0",
+						"lodash": "^4.17.13",
+						"resolve": "^1.3.2",
+						"semver": "^5.4.1",
+						"source-map": "^0.5.0"
 					},
 					"dependencies": {
-						"regenerator-runtime": {
-							"version": "0.13.2",
+						"source-map": {
+							"version": "0.5.7",
 							"bundled": true,
 							"dev": true
 						}
 					}
 				},
+				"@babel/generator": {
+					"version": "7.7.4",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.7.4",
+						"jsesc": "^2.5.1",
+						"lodash": "^4.17.13",
+						"source-map": "^0.5.0"
+					},
+					"dependencies": {
+						"source-map": {
+							"version": "0.5.7",
+							"bundled": true,
+							"dev": true
+						}
+					}
+				},
+				"@babel/helper-builder-react-jsx": {
+					"version": "7.7.4",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.7.4",
+						"esutils": "^2.0.0"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.7.4",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"@babel/helper-get-function-arity": "^7.7.4",
+						"@babel/template": "^7.7.4",
+						"@babel/types": "^7.7.4"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.7.4",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.7.4"
+					}
+				},
+				"@babel/helper-plugin-utils": {
+					"version": "7.0.0",
+					"bundled": true,
+					"dev": true
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.7.4",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"@babel/types": "^7.7.4"
+					}
+				},
+				"@babel/helpers": {
+					"version": "7.7.4",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"@babel/template": "^7.7.4",
+						"@babel/traverse": "^7.7.4",
+						"@babel/types": "^7.7.4"
+					}
+				},
+				"@babel/highlight": {
+					"version": "7.5.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"chalk": "^2.0.0",
+						"esutils": "^2.0.2",
+						"js-tokens": "^4.0.0"
+					},
+					"dependencies": {
+						"chalk": {
+							"version": "2.4.2",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"ansi-styles": "^3.2.1",
+								"escape-string-regexp": "^1.0.5",
+								"supports-color": "^5.3.0"
+							}
+						},
+						"supports-color": {
+							"version": "5.5.0",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"has-flag": "^3.0.0"
+							}
+						}
+					}
+				},
+				"@babel/parser": {
+					"version": "7.7.5",
+					"bundled": true,
+					"dev": true
+				},
+				"@babel/plugin-proposal-object-rest-spread": {
+					"version": "7.7.4",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0",
+						"@babel/plugin-syntax-object-rest-spread": "^7.7.4"
+					}
+				},
+				"@babel/plugin-syntax-jsx": {
+					"version": "7.7.4",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-syntax-object-rest-spread": {
+					"version": "7.7.4",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-transform-destructuring": {
+					"version": "7.7.4",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.0.0"
+					}
+				},
+				"@babel/plugin-transform-react-jsx": {
+					"version": "7.7.4",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"@babel/helper-builder-react-jsx": "^7.7.4",
+						"@babel/helper-plugin-utils": "^7.0.0",
+						"@babel/plugin-syntax-jsx": "^7.7.4"
+					}
+				},
+				"@babel/runtime": {
+					"version": "7.7.6",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"regenerator-runtime": "^0.13.2"
+					}
+				},
+				"@babel/template": {
+					"version": "7.7.4",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.0.0",
+						"@babel/parser": "^7.7.4",
+						"@babel/types": "^7.7.4"
+					}
+				},
+				"@babel/traverse": {
+					"version": "7.7.4",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"@babel/code-frame": "^7.5.5",
+						"@babel/generator": "^7.7.4",
+						"@babel/helper-function-name": "^7.7.4",
+						"@babel/helper-split-export-declaration": "^7.7.4",
+						"@babel/parser": "^7.7.4",
+						"@babel/types": "^7.7.4",
+						"debug": "^4.1.0",
+						"globals": "^11.1.0",
+						"lodash": "^4.17.13"
+					}
+				},
+				"@babel/types": {
+					"version": "7.7.4",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"esutils": "^2.0.2",
+						"lodash": "^4.17.13",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"@types/color-name": {
+					"version": "1.1.1",
+					"bundled": true,
+					"dev": true
+				},
 				"@types/prop-types": {
-					"version": "15.7.1",
+					"version": "15.7.3",
 					"bundled": true,
 					"dev": true
 				},
 				"@types/react": {
-					"version": "16.8.22",
+					"version": "16.9.16",
 					"bundled": true,
 					"dev": true,
 					"requires": {
@@ -2347,19 +2523,25 @@
 					}
 				},
 				"ansi-escapes": {
-					"version": "3.2.0",
+					"version": "4.3.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"requires": {
+						"type-fest": "^0.8.1"
+					}
 				},
 				"ansi-regex": {
-					"version": "2.1.1",
+					"version": "5.0.0",
 					"bundled": true,
 					"dev": true
 				},
 				"ansi-styles": {
-					"version": "2.2.1",
+					"version": "3.2.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"requires": {
+						"color-convert": "^1.9.0"
+					}
 				},
 				"ansicolors": {
 					"version": "0.3.2",
@@ -2367,247 +2549,19 @@
 					"dev": true
 				},
 				"arrify": {
-					"version": "1.0.1",
+					"version": "2.0.1",
 					"bundled": true,
 					"dev": true
 				},
 				"astral-regex": {
-					"version": "1.0.0",
+					"version": "2.0.0",
 					"bundled": true,
 					"dev": true
 				},
 				"auto-bind": {
-					"version": "2.1.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"@types/react": "^16.8.12"
-					}
-				},
-				"babel-code-frame": {
-					"version": "6.26.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"chalk": "^1.1.3",
-						"esutils": "^2.0.2",
-						"js-tokens": "^3.0.2"
-					}
-				},
-				"babel-core": {
-					"version": "6.26.3",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"babel-code-frame": "^6.26.0",
-						"babel-generator": "^6.26.0",
-						"babel-helpers": "^6.24.1",
-						"babel-messages": "^6.23.0",
-						"babel-register": "^6.26.0",
-						"babel-runtime": "^6.26.0",
-						"babel-template": "^6.26.0",
-						"babel-traverse": "^6.26.0",
-						"babel-types": "^6.26.0",
-						"babylon": "^6.18.0",
-						"convert-source-map": "^1.5.1",
-						"debug": "^2.6.9",
-						"json5": "^0.5.1",
-						"lodash": "^4.17.4",
-						"minimatch": "^3.0.4",
-						"path-is-absolute": "^1.0.1",
-						"private": "^0.1.8",
-						"slash": "^1.0.0",
-						"source-map": "^0.5.7"
-					},
-					"dependencies": {
-						"source-map": {
-							"version": "0.5.7",
-							"bundled": true,
-							"dev": true
-						}
-					}
-				},
-				"babel-generator": {
-					"version": "6.26.1",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"babel-messages": "^6.23.0",
-						"babel-runtime": "^6.26.0",
-						"babel-types": "^6.26.0",
-						"detect-indent": "^4.0.0",
-						"jsesc": "^1.3.0",
-						"lodash": "^4.17.4",
-						"source-map": "^0.5.7",
-						"trim-right": "^1.0.1"
-					},
-					"dependencies": {
-						"source-map": {
-							"version": "0.5.7",
-							"bundled": true,
-							"dev": true
-						}
-					}
-				},
-				"babel-helper-builder-react-jsx": {
-					"version": "6.26.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"babel-runtime": "^6.26.0",
-						"babel-types": "^6.26.0",
-						"esutils": "^2.0.2"
-					}
-				},
-				"babel-helpers": {
-					"version": "6.24.1",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"babel-runtime": "^6.22.0",
-						"babel-template": "^6.24.1"
-					}
-				},
-				"babel-messages": {
-					"version": "6.23.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"babel-runtime": "^6.22.0"
-					}
-				},
-				"babel-plugin-syntax-jsx": {
-					"version": "6.18.0",
+					"version": "3.0.0",
 					"bundled": true,
 					"dev": true
-				},
-				"babel-plugin-syntax-object-rest-spread": {
-					"version": "6.13.0",
-					"bundled": true,
-					"dev": true
-				},
-				"babel-plugin-transform-es2015-destructuring": {
-					"version": "6.23.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"babel-runtime": "^6.22.0"
-					}
-				},
-				"babel-plugin-transform-object-rest-spread": {
-					"version": "6.26.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"babel-plugin-syntax-object-rest-spread": "^6.8.0",
-						"babel-runtime": "^6.26.0"
-					}
-				},
-				"babel-plugin-transform-react-jsx": {
-					"version": "6.24.1",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"babel-helper-builder-react-jsx": "^6.24.1",
-						"babel-plugin-syntax-jsx": "^6.8.0",
-						"babel-runtime": "^6.22.0"
-					}
-				},
-				"babel-register": {
-					"version": "6.26.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"babel-core": "^6.26.0",
-						"babel-runtime": "^6.26.0",
-						"core-js": "^2.5.0",
-						"home-or-tmp": "^2.0.0",
-						"lodash": "^4.17.4",
-						"mkdirp": "^0.5.1",
-						"source-map-support": "^0.4.15"
-					},
-					"dependencies": {
-						"source-map": {
-							"version": "0.5.7",
-							"bundled": true,
-							"dev": true
-						},
-						"source-map-support": {
-							"version": "0.4.18",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"source-map": "^0.5.6"
-							}
-						}
-					}
-				},
-				"babel-runtime": {
-					"version": "6.26.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"core-js": "^2.4.0",
-						"regenerator-runtime": "^0.11.0"
-					}
-				},
-				"babel-template": {
-					"version": "6.26.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"babel-runtime": "^6.26.0",
-						"babel-traverse": "^6.26.0",
-						"babel-types": "^6.26.0",
-						"babylon": "^6.18.0",
-						"lodash": "^4.17.4"
-					}
-				},
-				"babel-traverse": {
-					"version": "6.26.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"babel-code-frame": "^6.26.0",
-						"babel-messages": "^6.23.0",
-						"babel-runtime": "^6.26.0",
-						"babel-types": "^6.26.0",
-						"babylon": "^6.18.0",
-						"debug": "^2.6.8",
-						"globals": "^9.18.0",
-						"invariant": "^2.2.2",
-						"lodash": "^4.17.4"
-					}
-				},
-				"babel-types": {
-					"version": "6.26.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"babel-runtime": "^6.26.0",
-						"esutils": "^2.0.2",
-						"lodash": "^4.17.4",
-						"to-fast-properties": "^1.0.3"
-					}
-				},
-				"babylon": {
-					"version": "6.18.0",
-					"bundled": true,
-					"dev": true
-				},
-				"balanced-match": {
-					"version": "1.0.0",
-					"bundled": true,
-					"dev": true
-				},
-				"brace-expansion": {
-					"version": "1.1.11",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"balanced-match": "^1.0.0",
-						"concat-map": "0.0.1"
-					}
 				},
 				"caller-callsite": {
 					"version": "2.0.0",
@@ -2640,15 +2594,36 @@
 					}
 				},
 				"chalk": {
-					"version": "1.1.3",
+					"version": "3.0.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"ansi-styles": "^2.2.1",
-						"escape-string-regexp": "^1.0.2",
-						"has-ansi": "^2.0.0",
-						"strip-ansi": "^3.0.0",
-						"supports-color": "^2.0.0"
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					},
+					"dependencies": {
+						"ansi-styles": {
+							"version": "4.2.0",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"@types/color-name": "^1.1.1",
+								"color-convert": "^2.0.1"
+							}
+						},
+						"color-convert": {
+							"version": "2.0.1",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"color-name": "~1.1.4"
+							}
+						},
+						"color-name": {
+							"version": "1.1.4",
+							"bundled": true,
+							"dev": true
+						}
 					}
 				},
 				"ci-info": {
@@ -2657,20 +2632,20 @@
 					"dev": true
 				},
 				"cli-cursor": {
+					"version": "3.1.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"restore-cursor": "^3.1.0"
+					}
+				},
+				"cli-truncate": {
 					"version": "2.1.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"restore-cursor": "^2.0.0"
-					}
-				},
-				"cli-truncate": {
-					"version": "1.1.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"slice-ansi": "^1.0.0",
-						"string-width": "^2.0.0"
+						"slice-ansi": "^3.0.0",
+						"string-width": "^4.2.0"
 					}
 				},
 				"color-convert": {
@@ -2686,47 +2661,36 @@
 					"bundled": true,
 					"dev": true
 				},
-				"concat-map": {
-					"version": "0.0.1",
-					"bundled": true,
-					"dev": true
-				},
 				"convert-source-map": {
-					"version": "1.6.0",
+					"version": "1.7.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
 						"safe-buffer": "~5.1.1"
+					},
+					"dependencies": {
+						"safe-buffer": {
+							"version": "5.1.2",
+							"bundled": true,
+							"dev": true
+						}
 					}
 				},
-				"core-js": {
-					"version": "2.6.5",
-					"bundled": true,
-					"dev": true
-				},
 				"csstype": {
-					"version": "2.6.5",
+					"version": "2.6.8",
 					"bundled": true,
 					"dev": true
 				},
 				"debug": {
-					"version": "2.6.9",
+					"version": "4.1.1",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"ms": "2.0.0"
-					}
-				},
-				"detect-indent": {
-					"version": "4.0.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"repeating": "^2.0.0"
+						"ms": "^2.1.1"
 					}
 				},
 				"emoji-regex": {
-					"version": "7.0.3",
+					"version": "8.0.0",
 					"bundled": true,
 					"dev": true
 				},
@@ -2741,7 +2705,7 @@
 					"dev": true
 				},
 				"esutils": {
-					"version": "2.0.2",
+					"version": "2.0.3",
 					"bundled": true,
 					"dev": true
 				},
@@ -2751,137 +2715,51 @@
 					"dev": true
 				},
 				"globals": {
-					"version": "9.18.0",
+					"version": "11.12.0",
 					"bundled": true,
 					"dev": true
-				},
-				"has-ansi": {
-					"version": "2.0.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^2.0.0"
-					}
 				},
 				"has-flag": {
 					"version": "3.0.0",
 					"bundled": true,
 					"dev": true
 				},
-				"home-or-tmp": {
-					"version": "2.0.0",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"os-homedir": "^1.0.0",
-						"os-tmpdir": "^1.0.1"
-					}
-				},
 				"import-jsx": {
-					"version": "2.0.0",
+					"version": "3.0.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"babel-core": "^6.25.0",
-						"babel-plugin-transform-es2015-destructuring": "^6.23.0",
-						"babel-plugin-transform-object-rest-spread": "^6.23.0",
-						"babel-plugin-transform-react-jsx": "^6.24.1",
+						"@babel/core": "^7.5.5",
+						"@babel/plugin-proposal-object-rest-spread": "^7.5.5",
+						"@babel/plugin-transform-destructuring": "^7.5.0",
+						"@babel/plugin-transform-react-jsx": "^7.3.0",
 						"caller-path": "^2.0.0",
 						"resolve-from": "^3.0.0"
 					}
 				},
 				"ink": {
-					"version": "2.3.0",
+					"version": "2.6.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"@types/react": "^16.8.6",
-						"arrify": "^1.0.1",
-						"auto-bind": "^2.0.0",
-						"chalk": "^2.4.1",
-						"cli-cursor": "^2.1.0",
-						"cli-truncate": "^1.1.0",
+						"ansi-escapes": "^4.2.1",
+						"arrify": "^2.0.1",
+						"auto-bind": "^3.0.0",
+						"chalk": "^3.0.0",
+						"cli-cursor": "^3.1.0",
+						"cli-truncate": "^2.0.0",
 						"is-ci": "^2.0.0",
 						"lodash.throttle": "^4.1.1",
 						"log-update": "^3.0.0",
 						"prop-types": "^15.6.2",
-						"react-reconciler": "^0.20.0",
-						"scheduler": "^0.13.2",
+						"react-reconciler": "^0.24.0",
+						"scheduler": "^0.18.0",
 						"signal-exit": "^3.0.2",
-						"slice-ansi": "^1.0.0",
-						"string-length": "^2.0.0",
-						"widest-line": "^2.0.0",
-						"wrap-ansi": "^5.0.0",
+						"slice-ansi": "^3.0.0",
+						"string-length": "^3.1.0",
+						"widest-line": "^3.1.0",
+						"wrap-ansi": "^6.2.0",
 						"yoga-layout-prebuilt": "^1.9.3"
-					},
-					"dependencies": {
-						"ansi-regex": {
-							"version": "4.1.0",
-							"bundled": true,
-							"dev": true
-						},
-						"ansi-styles": {
-							"version": "3.2.1",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"color-convert": "^1.9.0"
-							}
-						},
-						"chalk": {
-							"version": "2.4.2",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"ansi-styles": "^3.2.1",
-								"escape-string-regexp": "^1.0.5",
-								"supports-color": "^5.3.0"
-							}
-						},
-						"string-width": {
-							"version": "3.1.0",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"emoji-regex": "^7.0.1",
-								"is-fullwidth-code-point": "^2.0.0",
-								"strip-ansi": "^5.1.0"
-							}
-						},
-						"strip-ansi": {
-							"version": "5.2.0",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"ansi-regex": "^4.1.0"
-							}
-						},
-						"supports-color": {
-							"version": "5.5.0",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"has-flag": "^3.0.0"
-							}
-						},
-						"wrap-ansi": {
-							"version": "5.1.0",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"ansi-styles": "^3.2.0",
-								"string-width": "^3.0.0",
-								"strip-ansi": "^5.0.0"
-							}
-						}
-					}
-				},
-				"invariant": {
-					"version": "2.2.4",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"loose-envify": "^1.0.0"
 					}
 				},
 				"is-ci": {
@@ -2892,36 +2770,31 @@
 						"ci-info": "^2.0.0"
 					}
 				},
-				"is-finite": {
-					"version": "1.0.2",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"number-is-nan": "^1.0.0"
-					}
-				},
 				"is-fullwidth-code-point": {
-					"version": "2.0.0",
+					"version": "3.0.0",
 					"bundled": true,
 					"dev": true
 				},
 				"js-tokens": {
-					"version": "3.0.2",
+					"version": "4.0.0",
 					"bundled": true,
 					"dev": true
 				},
 				"jsesc": {
-					"version": "1.3.0",
+					"version": "2.5.2",
 					"bundled": true,
 					"dev": true
 				},
 				"json5": {
-					"version": "0.5.1",
+					"version": "2.1.1",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"requires": {
+						"minimist": "^1.2.0"
+					}
 				},
 				"lodash": {
-					"version": "4.17.14",
+					"version": "4.17.15",
 					"bundled": true,
 					"dev": true
 				},
@@ -2931,7 +2804,7 @@
 					"dev": true
 				},
 				"log-update": {
-					"version": "3.2.0",
+					"version": "3.3.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
@@ -2940,17 +2813,54 @@
 						"wrap-ansi": "^5.0.0"
 					},
 					"dependencies": {
+						"ansi-escapes": {
+							"version": "3.2.0",
+							"bundled": true,
+							"dev": true
+						},
 						"ansi-regex": {
 							"version": "4.1.0",
 							"bundled": true,
 							"dev": true
 						},
-						"ansi-styles": {
-							"version": "3.2.1",
+						"cli-cursor": {
+							"version": "2.1.0",
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"color-convert": "^1.9.0"
+								"restore-cursor": "^2.0.0"
+							}
+						},
+						"emoji-regex": {
+							"version": "7.0.3",
+							"bundled": true,
+							"dev": true
+						},
+						"is-fullwidth-code-point": {
+							"version": "2.0.0",
+							"bundled": true,
+							"dev": true
+						},
+						"mimic-fn": {
+							"version": "1.2.0",
+							"bundled": true,
+							"dev": true
+						},
+						"onetime": {
+							"version": "2.0.1",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"mimic-fn": "^1.0.0"
+							}
+						},
+						"restore-cursor": {
+							"version": "2.0.0",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"onetime": "^2.0.0",
+								"signal-exit": "^3.0.2"
 							}
 						},
 						"string-width": {
@@ -2991,52 +2901,33 @@
 						"js-tokens": "^3.0.0 || ^4.0.0"
 					}
 				},
-				"minimatch": {
-					"version": "3.0.4",
+				"mimic-fn": {
+					"version": "2.1.0",
 					"bundled": true,
-					"dev": true,
-					"requires": {
-						"brace-expansion": "^1.1.7"
-					}
+					"dev": true
+				},
+				"minimist": {
+					"version": "1.2.0",
+					"bundled": true,
+					"dev": true
 				},
 				"minipass": {
-					"version": "2.3.5",
+					"version": "3.1.1",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"safe-buffer": "^5.1.2",
-						"yallist": "^3.0.0"
+						"yallist": "^4.0.0"
 					},
 					"dependencies": {
 						"yallist": {
-							"version": "3.0.3",
-							"bundled": true,
-							"dev": true
-						}
-					}
-				},
-				"mkdirp": {
-					"version": "0.5.1",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"minimist": "0.0.8"
-					},
-					"dependencies": {
-						"minimist": {
-							"version": "0.0.8",
+							"version": "4.0.0",
 							"bundled": true,
 							"dev": true
 						}
 					}
 				},
 				"ms": {
-					"version": "2.0.0",
-					"bundled": true,
-					"dev": true
-				},
-				"number-is-nan": {
-					"version": "1.0.1",
+					"version": "2.1.2",
 					"bundled": true,
 					"dev": true
 				},
@@ -3046,37 +2937,15 @@
 					"dev": true
 				},
 				"onetime": {
-					"version": "2.0.1",
+					"version": "5.1.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"mimic-fn": "^1.0.0"
-					},
-					"dependencies": {
-						"mimic-fn": {
-							"version": "1.2.0",
-							"bundled": true,
-							"dev": true
-						}
+						"mimic-fn": "^2.1.0"
 					}
 				},
-				"os-homedir": {
-					"version": "1.0.2",
-					"bundled": true,
-					"dev": true
-				},
-				"os-tmpdir": {
-					"version": "1.0.2",
-					"bundled": true,
-					"dev": true
-				},
-				"path-is-absolute": {
-					"version": "1.0.1",
-					"bundled": true,
-					"dev": true
-				},
-				"private": {
-					"version": "0.1.8",
+				"path-parse": {
+					"version": "1.0.6",
 					"bundled": true,
 					"dev": true
 				},
@@ -3095,31 +2964,20 @@
 					"bundled": true,
 					"dev": true
 				},
-				"react": {
-					"version": "16.8.6",
-					"bundled": true,
-					"dev": true,
-					"requires": {
-						"loose-envify": "^1.1.0",
-						"object-assign": "^4.1.1",
-						"prop-types": "^15.6.2",
-						"scheduler": "^0.13.6"
-					}
-				},
 				"react-is": {
-					"version": "16.8.6",
+					"version": "16.12.0",
 					"bundled": true,
 					"dev": true
 				},
 				"react-reconciler": {
-					"version": "0.20.4",
+					"version": "0.24.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
 						"loose-envify": "^1.1.0",
 						"object-assign": "^4.1.1",
 						"prop-types": "^15.6.2",
-						"scheduler": "^0.13.6"
+						"scheduler": "^0.18.0"
 					}
 				},
 				"redeyed": {
@@ -3131,16 +2989,16 @@
 					}
 				},
 				"regenerator-runtime": {
-					"version": "0.11.1",
+					"version": "0.13.3",
 					"bundled": true,
 					"dev": true
 				},
-				"repeating": {
-					"version": "2.0.1",
+				"resolve": {
+					"version": "1.13.1",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"is-finite": "^1.0.0"
+						"path-parse": "^1.0.6"
 					}
 				},
 				"resolve-from": {
@@ -3149,11 +3007,11 @@
 					"dev": true
 				},
 				"restore-cursor": {
-					"version": "2.0.0",
+					"version": "3.1.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"onetime": "^2.0.0",
+						"onetime": "^5.1.0",
 						"signal-exit": "^3.0.2"
 					}
 				},
@@ -3166,13 +3024,8 @@
 						"glob": "^7.1.3"
 					}
 				},
-				"safe-buffer": {
-					"version": "5.1.2",
-					"bundled": true,
-					"dev": true
-				},
 				"scheduler": {
-					"version": "0.13.6",
+					"version": "0.18.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
@@ -3180,92 +3033,119 @@
 						"object-assign": "^4.1.1"
 					}
 				},
+				"semver": {
+					"version": "5.7.1",
+					"bundled": true,
+					"dev": true
+				},
 				"signal-exit": {
 					"version": "3.0.2",
 					"bundled": true,
 					"dev": true
 				},
-				"slash": {
-					"version": "1.0.0",
-					"bundled": true,
-					"dev": true
-				},
 				"slice-ansi": {
-					"version": "1.0.0",
+					"version": "3.0.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"is-fullwidth-code-point": "^2.0.0"
+						"ansi-styles": "^4.0.0",
+						"astral-regex": "^2.0.0",
+						"is-fullwidth-code-point": "^3.0.0"
+					},
+					"dependencies": {
+						"ansi-styles": {
+							"version": "4.2.0",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"@types/color-name": "^1.1.1",
+								"color-convert": "^2.0.1"
+							}
+						},
+						"color-convert": {
+							"version": "2.0.1",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"color-name": "~1.1.4"
+							}
+						},
+						"color-name": {
+							"version": "1.1.4",
+							"bundled": true,
+							"dev": true
+						}
 					}
 				},
 				"string-length": {
-					"version": "2.0.0",
+					"version": "3.1.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
 						"astral-regex": "^1.0.0",
-						"strip-ansi": "^4.0.0"
+						"strip-ansi": "^5.2.0"
 					},
 					"dependencies": {
 						"ansi-regex": {
-							"version": "3.0.0",
+							"version": "4.1.0",
+							"bundled": true,
+							"dev": true
+						},
+						"astral-regex": {
+							"version": "1.0.0",
 							"bundled": true,
 							"dev": true
 						},
 						"strip-ansi": {
-							"version": "4.0.0",
+							"version": "5.2.0",
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"ansi-regex": "^3.0.0"
+								"ansi-regex": "^4.1.0"
 							}
 						}
 					}
 				},
 				"string-width": {
-					"version": "2.1.1",
+					"version": "4.2.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"is-fullwidth-code-point": "^2.0.0",
-						"strip-ansi": "^4.0.0"
-					},
-					"dependencies": {
-						"ansi-regex": {
-							"version": "3.0.0",
-							"bundled": true,
-							"dev": true
-						},
-						"strip-ansi": {
-							"version": "4.0.0",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"ansi-regex": "^3.0.0"
-							}
-						}
+						"emoji-regex": "^8.0.0",
+						"is-fullwidth-code-point": "^3.0.0",
+						"strip-ansi": "^6.0.0"
 					}
 				},
 				"strip-ansi": {
-					"version": "3.0.1",
+					"version": "6.0.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"ansi-regex": "^2.0.0"
+						"ansi-regex": "^5.0.0"
 					}
 				},
 				"supports-color": {
-					"version": "2.0.0",
+					"version": "7.1.0",
 					"bundled": true,
-					"dev": true
+					"dev": true,
+					"requires": {
+						"has-flag": "^4.0.0"
+					},
+					"dependencies": {
+						"has-flag": {
+							"version": "4.0.0",
+							"bundled": true,
+							"dev": true
+						}
+					}
 				},
 				"tap-parser": {
-					"version": "9.3.2",
+					"version": "10.0.1",
 					"bundled": true,
 					"dev": true,
 					"requires": {
 						"events-to-array": "^1.0.1",
-						"minipass": "^2.2.0",
+						"minipass": "^3.0.0",
 						"tap-yaml": "^1.0.0"
 					}
 				},
@@ -3278,55 +3158,36 @@
 					}
 				},
 				"to-fast-properties": {
-					"version": "1.0.3",
+					"version": "2.0.0",
 					"bundled": true,
 					"dev": true
 				},
 				"treport": {
-					"version": "0.4.0",
+					"version": "1.0.1",
 					"bundled": true,
 					"dev": true,
 					"requires": {
 						"cardinal": "^2.1.1",
-						"chalk": "^2.4.2",
-						"import-jsx": "^2.0.0",
-						"ink": "^2.1.1",
-						"ms": "^2.1.1",
-						"react": "^16.8.6",
-						"string-length": "^2.0.0",
-						"tap-parser": "^9.3.2",
-						"unicode-length": "^2.0.1"
+						"chalk": "^3.0.0",
+						"import-jsx": "^3.0.0",
+						"ink": "^2.5.0",
+						"ms": "^2.1.2",
+						"string-length": "^3.1.0",
+						"tap-parser": "^10.0.1",
+						"unicode-length": "^2.0.2"
 					},
 					"dependencies": {
-						"ansi-styles": {
-							"version": "3.2.1",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"color-convert": "^1.9.0"
-							}
-						},
-						"chalk": {
-							"version": "2.4.2",
-							"bundled": true,
-							"dev": true,
-							"requires": {
-								"ansi-styles": "^3.2.1",
-								"escape-string-regexp": "^1.0.5",
-								"supports-color": "^5.3.0"
-							}
-						},
-						"ms": {
-							"version": "2.1.2",
+						"ansi-regex": {
+							"version": "2.1.1",
 							"bundled": true,
 							"dev": true
 						},
-						"supports-color": {
-							"version": "5.5.0",
+						"strip-ansi": {
+							"version": "3.0.1",
 							"bundled": true,
 							"dev": true,
 							"requires": {
-								"has-flag": "^3.0.0"
+								"ansi-regex": "^2.0.0"
 							}
 						},
 						"unicode-length": {
@@ -3340,25 +3201,68 @@
 						}
 					}
 				},
-				"trim-right": {
-					"version": "1.0.1",
+				"type-fest": {
+					"version": "0.8.1",
 					"bundled": true,
 					"dev": true
 				},
+				"which": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+					"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+					"dev": true,
+					"requires": {
+						"isexe": "^2.0.0"
+					}
+				},
 				"widest-line": {
-					"version": "2.0.1",
+					"version": "3.1.0",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"string-width": "^2.1.1"
+						"string-width": "^4.0.0"
+					}
+				},
+				"wrap-ansi": {
+					"version": "6.2.0",
+					"bundled": true,
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.0.0",
+						"string-width": "^4.1.0",
+						"strip-ansi": "^6.0.0"
+					},
+					"dependencies": {
+						"ansi-styles": {
+							"version": "4.2.0",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"@types/color-name": "^1.1.1",
+								"color-convert": "^2.0.1"
+							}
+						},
+						"color-convert": {
+							"version": "2.0.1",
+							"bundled": true,
+							"dev": true,
+							"requires": {
+								"color-name": "~1.1.4"
+							}
+						},
+						"color-name": {
+							"version": "1.1.4",
+							"bundled": true,
+							"dev": true
+						}
 					}
 				},
 				"yaml": {
-					"version": "1.6.0",
+					"version": "1.7.2",
 					"bundled": true,
 					"dev": true,
 					"requires": {
-						"@babel/runtime": "^7.4.5"
+						"@babel/runtime": "^7.6.3"
 					}
 				},
 				"yoga-layout-prebuilt": {
@@ -3369,54 +3273,38 @@
 			}
 		},
 		"tap-mocha-reporter": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/tap-mocha-reporter/-/tap-mocha-reporter-4.0.1.tgz",
-			"integrity": "sha512-/KfXaaYeSPn8qBi5Be8WSIP3iKV83s2uj2vzImJAXmjNu22kzqZ+1Dv1riYWa53sPCiyo1R1w1jbJrftF8SpcQ==",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/tap-mocha-reporter/-/tap-mocha-reporter-5.0.1.tgz",
+			"integrity": "sha512-1knFWOwd4khx/7uSEnUeaP9IPW3w+sqTgJMhrwah6t46nZ8P25atOKAjSvVDsT67lOPu0nfdOqUwoyKn+3E5pA==",
 			"dev": true,
 			"requires": {
 				"color-support": "^1.1.0",
-				"debug": "^2.1.3",
-				"diff": "^1.3.2",
-				"escape-string-regexp": "^1.0.3",
+				"debug": "^4.1.1",
+				"diff": "^4.0.1",
+				"escape-string-regexp": "^2.0.0",
 				"glob": "^7.0.5",
-				"readable-stream": "^2.1.5",
-				"tap-parser": "^8.0.0",
-				"tap-yaml": "0 || 1",
-				"unicode-length": "^1.0.0"
+				"tap-parser": "^10.0.0",
+				"tap-yaml": "^1.0.0",
+				"unicode-length": "^2.0.2"
 			},
 			"dependencies": {
-				"debug": {
-					"version": "2.6.9",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-					"dev": true,
-					"requires": {
-						"ms": "2.0.0"
-					}
-				},
-				"diff": {
-					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
-					"integrity": "sha1-fyjS657nsVqX79ic5j3P2qPMur8=",
-					"dev": true
-				},
-				"ms": {
+				"escape-string-regexp": {
 					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+					"integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
 					"dev": true
 				}
 			}
 		},
 		"tap-parser": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/tap-parser/-/tap-parser-8.1.0.tgz",
-			"integrity": "sha512-GgOzgDwThYLxhVR83RbS1JUR1TxcT+jfZsrETgPAvFdr12lUOnuvrHOBaUQgpkAp6ZyeW6r2Nwd91t88M0ru3w==",
+			"version": "10.0.1",
+			"resolved": "https://registry.npmjs.org/tap-parser/-/tap-parser-10.0.1.tgz",
+			"integrity": "sha512-qdT15H0DoJIi7zOqVXDn9X0gSM68JjNy1w3VemwTJlDnETjbi6SutnqmBfjDJAwkFS79NJ97gZKqie00ZCGmzg==",
 			"dev": true,
 			"requires": {
 				"events-to-array": "^1.0.1",
-				"minipass": "^2.2.0",
-				"tap-yaml": "0 || 1"
+				"minipass": "^3.0.0",
+				"tap-yaml": "^1.0.0"
 			}
 		},
 		"tap-yaml": {
@@ -3429,10 +3317,13 @@
 			}
 		},
 		"tcompare": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/tcompare/-/tcompare-2.3.0.tgz",
-			"integrity": "sha512-fAfA73uFtFGybWGt4+IYT6UPLYVZQ4NfsP+IXEZGY0vh8e2IF7LVKafcQNMRBLqP0wzEA65LM9Tqj+FSmO8GLw==",
-			"dev": true
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/tcompare/-/tcompare-3.0.4.tgz",
+			"integrity": "sha512-Q3TitMVK59NyKgQyFh+857wTAUE329IzLDehuPgU4nF5e8g+EUQ+yUbjUy1/6ugiNnXztphT+NnqlCXolv9P3A==",
+			"dev": true,
+			"requires": {
+				"diff-frag": "^1.0.1"
+			}
 		},
 		"test-exclude": {
 			"version": "5.2.3",
@@ -3479,12 +3370,6 @@
 				}
 			}
 		},
-		"trim-right": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
-			"integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
-			"dev": true
-		},
 		"trivial-deferred": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/trivial-deferred/-/trivial-deferred-1.0.1.tgz",
@@ -3492,16 +3377,16 @@
 			"dev": true
 		},
 		"ts-node": {
-			"version": "8.3.0",
-			"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.3.0.tgz",
-			"integrity": "sha512-dyNS/RqyVTDcmNM4NIBAeDMpsAdaQ+ojdf0GOLqE6nwJOgzEkdRNzJywhDfwnuvB10oa6NLVG1rUJQCpRN7qoQ==",
+			"version": "8.6.0",
+			"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.6.0.tgz",
+			"integrity": "sha512-NVJ/5ZjrxCS445zMIxGWiieTZoWcHbqtVKa+1V7opSmOFCYi7fvkugEXZBC9IvUnEzNewZWy8dw0u6iSTridpA==",
 			"dev": true,
 			"requires": {
 				"arg": "^4.1.0",
 				"diff": "^4.0.1",
 				"make-error": "^1.1.1",
 				"source-map-support": "^0.5.6",
-				"yn": "^3.0.0"
+				"yn": "^4.0.0"
 			}
 		},
 		"tunnel-agent": {
@@ -3529,29 +3414,29 @@
 			}
 		},
 		"typescript": {
-			"version": "3.6.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.3.tgz",
-			"integrity": "sha512-N7bceJL1CtRQ2RiG0AQME13ksR7DiuQh/QehubYcghzv20tnh+MQnQIuJddTmsbqYj+dztchykemz0zFzlvdQw==",
+			"version": "3.7.4",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.4.tgz",
+			"integrity": "sha512-A25xv5XCtarLwXpcDNZzCGvW2D1S3/bACratYBx2sax8PefsFhlYmkQicKHvpYflFS8if4zne5zT5kpJ7pzuvw==",
 			"dev": true
 		},
 		"uglify-js": {
-			"version": "3.6.0",
-			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.0.tgz",
-			"integrity": "sha512-W+jrUHJr3DXKhrsS7NUVxn3zqMOFn0hL/Ei6v0anCIMoKC93TjcflTagwIHLW7SfMFfiQuktQyFVCFHGUE0+yg==",
+			"version": "3.7.4",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.7.4.tgz",
+			"integrity": "sha512-tinYWE8X1QfCHxS1lBS8yiDekyhSXOO6R66yNOCdUJeojxxw+PX2BHAz/BWyW7PQ7pkiWVxJfIEbiDxyLWvUGg==",
 			"dev": true,
 			"optional": true,
 			"requires": {
-				"commander": "~2.20.0",
+				"commander": "~2.20.3",
 				"source-map": "~0.6.1"
 			}
 		},
 		"unicode-length": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/unicode-length/-/unicode-length-1.0.3.tgz",
-			"integrity": "sha1-Wtp6f+1RhBpBijKM8UlHisg1irs=",
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/unicode-length/-/unicode-length-2.0.2.tgz",
+			"integrity": "sha512-Ph/j1VbS3/r77nhoY2WU0GWGjVYOHL3xpKp0y/Eq2e5r0mT/6b649vm7KFO6RdAdrZkYLdxphYVgvODxPB+Ebg==",
 			"dev": true,
 			"requires": {
-				"punycode": "^1.3.2",
+				"punycode": "^2.0.0",
 				"strip-ansi": "^3.0.1"
 			},
 			"dependencies": {
@@ -3559,12 +3444,6 @@
 					"version": "2.1.1",
 					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
 					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-					"dev": true
-				},
-				"punycode": {
-					"version": "1.4.1",
-					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-					"integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
 					"dev": true
 				},
 				"strip-ansi": {
@@ -3586,13 +3465,6 @@
 			"requires": {
 				"punycode": "^2.1.0"
 			}
-		},
-		"util-deprecate": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-			"dev": true,
-			"optional": true
 		},
 		"uuid": {
 			"version": "3.3.3",
@@ -3700,9 +3572,9 @@
 			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
 		},
 		"write-file-atomic": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.0.tgz",
-			"integrity": "sha512-EIgkf60l2oWsffja2Sf2AL384dx328c0B+cIYPTQq5q2rOYuDV00/iPFBOUiDKKwKMOhkymH8AidPaRvzfxY+Q==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.1.tgz",
+			"integrity": "sha512-JPStrIyyVJ6oCSz/691fAjFtefZ6q+fP6tm+OS4Qw6o+TGQxNp1ziY2PgS+X/m0V8OWhZiO/m4xSj+Pr4RrZvw==",
 			"dev": true,
 			"requires": {
 				"imurmurhash": "^0.1.4",
@@ -3724,12 +3596,12 @@
 			"dev": true
 		},
 		"yaml": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-1.6.0.tgz",
-			"integrity": "sha512-iZfse3lwrJRoSlfs/9KQ9iIXxs9++RvBFVzAqbbBiFT+giYtyanevreF9r61ZTbGMgWQBxAua3FzJiniiJXWWw==",
+			"version": "1.7.2",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-1.7.2.tgz",
+			"integrity": "sha512-qXROVp90sb83XtAoqE8bP9RwAkTTZbugRUTm5YeFCBfNRPEp2YzTeqWiz7m5OORHzEvrA/qcGS8hp/E+MMROYw==",
 			"dev": true,
 			"requires": {
-				"@babel/runtime": "^7.4.5"
+				"@babel/runtime": "^7.6.3"
 			}
 		},
 		"yamljs": {
@@ -3826,9 +3698,9 @@
 			}
 		},
 		"yn": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-			"integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/yn/-/yn-4.0.0.tgz",
+			"integrity": "sha512-huWiiCS4TxKc4SfgmTwW1K7JmXPPAmuXWYy4j9qjQo4+27Kni8mGhAAi1cloRWmBe2EqcLgt3IGqQoRL/MtPgg==",
 			"dev": true
 		}
 	}

--- a/packages/util/package-lock.json
+++ b/packages/util/package-lock.json
@@ -49,9 +49,9 @@
 			"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
 		},
 		"aws4": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
-			"integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
+			"version": "1.9.0",
+			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.0.tgz",
+			"integrity": "sha512-Uvq6hVe90D0B2WEnUqtdgY1bATGz3mw33nH9Y+dmA+w5DHvUmBgkr5rM/KCHpCsiFNRUfokW/szpPPgMK2hm4A=="
 		},
 		"balanced-match": {
 			"version": "1.0.0",
@@ -164,9 +164,9 @@
 			"integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
 		},
 		"fast-json-stable-stringify": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-			"integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
 		},
 		"forever-agent": {
 			"version": "0.6.1",
@@ -288,16 +288,16 @@
 			"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
 		},
 		"mime-db": {
-			"version": "1.40.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
-			"integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA=="
+			"version": "1.43.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.43.0.tgz",
+			"integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ=="
 		},
 		"mime-types": {
-			"version": "2.1.24",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
-			"integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
+			"version": "2.1.26",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.26.tgz",
+			"integrity": "sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==",
 			"requires": {
-				"mime-db": "1.40.0"
+				"mime-db": "1.43.0"
 			}
 		},
 		"minimatch": {
@@ -460,9 +460,9 @@
 			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
 		},
 		"uuid": {
-			"version": "3.3.2",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-			"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
+			"integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ=="
 		},
 		"verror": {
 			"version": "1.10.0",


### PR DESCRIPTION
Fix the security vulnerability CVE-2019-19919 reported for our dev-dependencies.
