### PR TITLE
Fix language alias for http function

### DIFF
--- a/packages/runtime/src/helper.ts
+++ b/packages/runtime/src/helper.ts
@@ -869,7 +869,11 @@ export function getLanguageFromRequest(
     return defaultLanguage;
   }
 
-  const reqLanguage = req.headers['accept-language'];
+  let languages = req.headers['accept-language'].split(',');
+  for (let i = 0; i < languages.length; i++) {
+    languages[i] = getLangAlias(languages[i]);
+  }
+  const reqLanguage = languages.join(',');
   if (!reqLanguage) {
     return defaultLanguage;
   }

--- a/packages/runtime/src/strong-globalize.ts
+++ b/packages/runtime/src/strong-globalize.ts
@@ -354,12 +354,11 @@ export class StrongGlobalize {
     StrongGlobalize
   >(); /* eslint-env es6 */
   http(req: {headers: AnyObject}) {
-    let matchingLang = helper.getLanguageFromRequest(
+    const matchingLang = helper.getLanguageFromRequest(
       req,
       this._options.appLanguages,
       this._options.language
     );
-    matchingLang = getLangAlias(matchingLang);
 
     let sg = StrongGlobalize.sgCache.get(matchingLang);
     if (sg) {

--- a/packages/runtime/test/test-load-msg.js
+++ b/packages/runtime/test/test-load-msg.js
@@ -11,7 +11,7 @@ var test = require('tap').test;
 
 SG.SetRootDir(__dirname);
 SG.SetDefaultLanguage();
-SG.SetAppLanguages(['en', 'zh-cn', 'zh-Hans']);
+SG.SetAppLanguages(['en', 'zh-Hans']);
 
 var g = new SG();
 


### PR DESCRIPTION
**Purpose:** 
The purpose of this PR is to:
1. Fix the test that was checking on the language aliases when `http(req)` is called.
2. Fix when aliases work when `g.http(req)` is called.

**Tests:**
The tests that were in previously for aliases are appropriate for this PR. However, I modified the AppLanguages in order to correctly reflect a `strong-globalize` environment.

**Explanation:**
The original tests missed the scenario I'm running into now: The http function doesn't map the alias properly when the alias language is not in the `appLanguages`. 

For example: Say my acceptedLanguages (which is determined by my folder structure) is `cs, en, zh-Hans, zh-Hant`.

`g.http` will not map properly to `zh-Hans` because `zh-cn` is not in the `appLanguages`. Instead, the `acceptLanguage` function will return the first language in the `appLanguages` list. (In this case, `cs`) When getLangAlias is called it simply matches `cs` with `cs`, but by then the language is wrong. 

This was not caught in the test because in the test we included `zh-cn` as part of the `appLanguages`. This returns a result from `accept-language` that is not expected. See: [here](https://github.com/strongloop/strong-globalize/pull/153#discussion_r371431446). Alias conversion should work if `appLanguages` = `en, zh-Hans`. Otherwise, the intl folder structure would be:
```
intl
├── en
├── zh-cn
├── zh-Hans
```
which is incorrect if zh-Hans is to equivocate to zh-cn.
