### PR TITLE
chore: update copyrights year

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
-// Copyright IBM Corp. 2015,2018. All Rights Reserved.
-// Node module: strong-globalize
+// Copyright IBM Corp. 2018,2020. All Rights Reserved.
+// Node module: strong-globalize-cli
 // This file is licensed under the Artistic License 2.0.
 // License text available at https://opensource.org/licenses/Artistic-2.0
 

--- a/packages/cli/src/extract.ts
+++ b/packages/cli/src/extract.ts
@@ -1,5 +1,5 @@
-// Copyright IBM Corp. 2015,2018. All Rights Reserved.
-// Node module: strong-globalize
+// Copyright IBM Corp. 2018,2020. All Rights Reserved.
+// Node module: strong-globalize-cli
 // This file is licensed under the Artistic License 2.0.
 // License text available at https://opensource.org/licenses/Artistic-2.0
 

--- a/packages/cli/src/lint.ts
+++ b/packages/cli/src/lint.ts
@@ -1,5 +1,5 @@
-// Copyright IBM Corp. 2015,2016. All Rights Reserved.
-// Node module: strong-globalize
+// Copyright IBM Corp. 2018,2020. All Rights Reserved.
+// Node module: strong-globalize-cli
 // This file is licensed under the Artistic License 2.0.
 // License text available at https://opensource.org/licenses/Artistic-2.0
 

--- a/packages/cli/src/promisify.ts
+++ b/packages/cli/src/promisify.ts
@@ -1,7 +1,7 @@
-// Copyright IBM Corp. 2017,2018. All Rights Reserved.
-// Node module: @loopback/core
-// This file is licensed under the MIT License.
-// License text available at https://opensource.org/licenses/MIT
+// Copyright IBM Corp. 2018,2020. All Rights Reserved.
+// Node module: strong-globalize-cli
+// This file is licensed under the Artistic License 2.0.
+// License text available at https://opensource.org/licenses/Artistic-2.0
 
 // A temporary polyfill for util.promisify on Node.js 6.x
 // Remove it as part of https://github.com/strongloop/loopback-next/issues/611

--- a/packages/cli/src/translate.ts
+++ b/packages/cli/src/translate.ts
@@ -1,5 +1,5 @@
-// Copyright IBM Corp. 2015,2018. All Rights Reserved.
-// Node module: strong-globalize
+// Copyright IBM Corp. 2018,2020. All Rights Reserved.
+// Node module: strong-globalize-cli
 // This file is licensed under the Artistic License 2.0.
 // License text available at https://opensource.org/licenses/Artistic-2.0
 

--- a/packages/cli/test/gpb-translate-helper.js
+++ b/packages/cli/test/gpb-translate-helper.js
@@ -1,7 +1,8 @@
-// Copyright IBM Corp. 2016. All Rights Reserved.
-// Node module: strong-globalize
+// Copyright IBM Corp. 2018,2020. All Rights Reserved.
+// Node module: strong-globalize-cli
 // This file is licensed under the Artistic License 2.0.
 // License text available at https://opensource.org/licenses/Artistic-2.0
+
 'use strict';
 
 var gpb = require('g11n-pipeline');

--- a/packages/cli/test/load-msg-helper.js
+++ b/packages/cli/test/load-msg-helper.js
@@ -1,7 +1,8 @@
-// Copyright IBM Corp. 2016. All Rights Reserved.
-// Node module: strong-globalize
+// Copyright IBM Corp. 2018,2020. All Rights Reserved.
+// Node module: strong-globalize-cli
 // This file is licensed under the Artistic License 2.0.
 // License text available at https://opensource.org/licenses/Artistic-2.0
+
 'use strict';
 
 var SG = require('strong-globalize');

--- a/packages/cli/test/node_modules/fifth/index.js
+++ b/packages/cli/test/node_modules/fifth/index.js
@@ -1,5 +1,5 @@
-// Copyright IBM Corp. 2016. All Rights Reserved.
-// Node module: strong-globalize
+// Copyright IBM Corp. 2018,2020. All Rights Reserved.
+// Node module: strong-globalize-cli
 // This file is licensed under the Artistic License 2.0.
 // License text available at https://opensource.org/licenses/Artistic-2.0
 

--- a/packages/cli/test/node_modules/fourth/index.js
+++ b/packages/cli/test/node_modules/fourth/index.js
@@ -1,5 +1,5 @@
-// Copyright IBM Corp. 2016. All Rights Reserved.
-// Node module: strong-globalize
+// Copyright IBM Corp. 2018,2020. All Rights Reserved.
+// Node module: strong-globalize-cli
 // This file is licensed under the Artistic License 2.0.
 // License text available at https://opensource.org/licenses/Artistic-2.0
 

--- a/packages/cli/test/node_modules/secondary/index.js
+++ b/packages/cli/test/node_modules/secondary/index.js
@@ -1,5 +1,5 @@
-// Copyright IBM Corp. 2016. All Rights Reserved.
-// Node module: strong-globalize
+// Copyright IBM Corp. 2018,2020. All Rights Reserved.
+// Node module: strong-globalize-cli
 // This file is licensed under the Artistic License 2.0.
 // License text available at https://opensource.org/licenses/Artistic-2.0
 

--- a/packages/cli/test/node_modules/third/index.js
+++ b/packages/cli/test/node_modules/third/index.js
@@ -1,5 +1,5 @@
-// Copyright IBM Corp. 2016. All Rights Reserved.
-// Node module: strong-globalize
+// Copyright IBM Corp. 2018,2020. All Rights Reserved.
+// Node module: strong-globalize-cli
 // This file is licensed under the Artistic License 2.0.
 // License text available at https://opensource.org/licenses/Artistic-2.0
 

--- a/packages/cli/test/node_modules/third/node_modules/fourth/index.js
+++ b/packages/cli/test/node_modules/third/node_modules/fourth/index.js
@@ -1,5 +1,5 @@
-// Copyright IBM Corp. 2016. All Rights Reserved.
-// Node module: strong-globalize
+// Copyright IBM Corp. 2018,2020. All Rights Reserved.
+// Node module: strong-globalize-cli
 // This file is licensed under the Artistic License 2.0.
 // License text available at https://opensource.org/licenses/Artistic-2.0
 

--- a/packages/cli/test/slt-test-helper.js
+++ b/packages/cli/test/slt-test-helper.js
@@ -1,7 +1,8 @@
-// Copyright IBM Corp. 2016. All Rights Reserved.
-// Node module: strong-globalize
+// Copyright IBM Corp. 2018,2020. All Rights Reserved.
+// Node module: strong-globalize-cli
 // This file is licensed under the Artistic License 2.0.
 // License text available at https://opensource.org/licenses/Artistic-2.0
+
 'use strict';
 
 var async = require('async');

--- a/packages/cli/test/test-auto-msg-load.js
+++ b/packages/cli/test/test-auto-msg-load.js
@@ -1,7 +1,8 @@
-// Copyright IBM Corp. 2016. All Rights Reserved.
-// Node module: strong-globalize
+// Copyright IBM Corp. 2018,2020. All Rights Reserved.
+// Node module: strong-globalize-cli
 // This file is licensed under the Artistic License 2.0.
 // License text available at https://opensource.org/licenses/Artistic-2.0
+
 'use strict';
 
 var SG = require('strong-globalize');

--- a/packages/cli/test/test-extract-2.js
+++ b/packages/cli/test/test-extract-2.js
@@ -1,7 +1,8 @@
-// Copyright IBM Corp. 2016. All Rights Reserved.
-// Node module: strong-globalize
+// Copyright IBM Corp. 2018,2020. All Rights Reserved.
+// Node module: strong-globalize-cli
 // This file is licensed under the Artistic License 2.0.
 // License text available at https://opensource.org/licenses/Artistic-2.0
+
 'use strict';
 
 var extract = require('../lib/extract');

--- a/packages/cli/test/test-extract-3.js
+++ b/packages/cli/test/test-extract-3.js
@@ -1,7 +1,8 @@
-// Copyright IBM Corp. 2016. All Rights Reserved.
-// Node module: strong-globalize
+// Copyright IBM Corp. 2018,2020. All Rights Reserved.
+// Node module: strong-globalize-cli
 // This file is licensed under the Artistic License 2.0.
 // License text available at https://opensource.org/licenses/Artistic-2.0
+
 'use strict';
 
 var extract = require('../lib/extract');

--- a/packages/cli/test/test-extract-4.js
+++ b/packages/cli/test/test-extract-4.js
@@ -1,7 +1,8 @@
-// Copyright IBM Corp. 2016. All Rights Reserved.
-// Node module: strong-globalize
+// Copyright IBM Corp. 2018,2020. All Rights Reserved.
+// Node module: strong-globalize-cli
 // This file is licensed under the Artistic License 2.0.
 // License text available at https://opensource.org/licenses/Artistic-2.0
+
 'use strict';
 
 var extract = require('../lib/extract');

--- a/packages/cli/test/test-extract-json.js
+++ b/packages/cli/test/test-extract-json.js
@@ -1,7 +1,8 @@
-// Copyright IBM Corp. 2016. All Rights Reserved.
-// Node module: strong-globalize
+// Copyright IBM Corp. 2018,2020. All Rights Reserved.
+// Node module: strong-globalize-cli
 // This file is licensed under the Artistic License 2.0.
 // License text available at https://opensource.org/licenses/Artistic-2.0
+
 'use strict';
 
 var extract = require('../lib/extract');

--- a/packages/cli/test/test-extract-shared-globalize.js
+++ b/packages/cli/test/test-extract-shared-globalize.js
@@ -1,7 +1,8 @@
-// Copyright IBM Corp. 2016. All Rights Reserved.
-// Node module: strong-globalize
+// Copyright IBM Corp. 2018,2020. All Rights Reserved.
+// Node module: strong-globalize-cli
 // This file is licensed under the Artistic License 2.0.
 // License text available at https://opensource.org/licenses/Artistic-2.0
+
 'use strict';
 
 var extract = require('../lib/extract');

--- a/packages/cli/test/test-extract.js
+++ b/packages/cli/test/test-extract.js
@@ -1,7 +1,8 @@
-// Copyright IBM Corp. 2016. All Rights Reserved.
-// Node module: strong-globalize
+// Copyright IBM Corp. 2018,2020. All Rights Reserved.
+// Node module: strong-globalize-cli
 // This file is licensed under the Artistic License 2.0.
 // License text available at https://opensource.org/licenses/Artistic-2.0
+
 'use strict';
 
 var SG = require('strong-globalize');

--- a/packages/cli/test/test-lint.js
+++ b/packages/cli/test/test-lint.js
@@ -1,7 +1,8 @@
-// Copyright IBM Corp. 2016. All Rights Reserved.
-// Node module: strong-globalize
+// Copyright IBM Corp. 2018,2020. All Rights Reserved.
+// Node module: strong-globalize-cli
 // This file is licensed under the Artistic License 2.0.
 // License text available at https://opensource.org/licenses/Artistic-2.0
+
 'use strict';
 
 var lint = require('../lib/lint');

--- a/packages/cli/test/test-setregex.js
+++ b/packages/cli/test/test-setregex.js
@@ -1,7 +1,8 @@
-// Copyright IBM Corp. 2016. All Rights Reserved.
-// Node module: strong-globalize
+// Copyright IBM Corp. 2018,2020. All Rights Reserved.
+// Node module: strong-globalize-cli
 // This file is licensed under the Artistic License 2.0.
 // License text available at https://opensource.org/licenses/Artistic-2.0
+
 'use strict';
 
 var extract = require('../lib/extract');

--- a/packages/cli/test/test-translate-2.js
+++ b/packages/cli/test/test-translate-2.js
@@ -1,7 +1,8 @@
-// Copyright IBM Corp. 2016. All Rights Reserved.
-// Node module: strong-globalize
+// Copyright IBM Corp. 2018,2020. All Rights Reserved.
+// Node module: strong-globalize-cli
 // This file is licensed under the Artistic License 2.0.
 // License text available at https://opensource.org/licenses/Artistic-2.0
+
 'use strict';
 
 var sltTH = require('./slt-test-helper');

--- a/packages/cli/test/test-translate-3.js
+++ b/packages/cli/test/test-translate-3.js
@@ -1,7 +1,8 @@
-// Copyright IBM Corp. 2016. All Rights Reserved.
-// Node module: strong-globalize
+// Copyright IBM Corp. 2018,2020. All Rights Reserved.
+// Node module: strong-globalize-cli
 // This file is licensed under the Artistic License 2.0.
 // License text available at https://opensource.org/licenses/Artistic-2.0
+
 'use strict';
 
 var gpbHelper = require('./gpb-translate-helper');

--- a/packages/cli/test/test-translate-4.js
+++ b/packages/cli/test/test-translate-4.js
@@ -1,7 +1,8 @@
-// Copyright IBM Corp. 2016. All Rights Reserved.
-// Node module: strong-globalize
+// Copyright IBM Corp. 2018,2020. All Rights Reserved.
+// Node module: strong-globalize-cli
 // This file is licensed under the Artistic License 2.0.
 // License text available at https://opensource.org/licenses/Artistic-2.0
+
 'use strict';
 
 var gpbHelper = require('./gpb-translate-helper');

--- a/packages/cli/test/test-translate-5.js
+++ b/packages/cli/test/test-translate-5.js
@@ -1,7 +1,8 @@
-// Copyright IBM Corp. 2016. All Rights Reserved.
-// Node module: strong-globalize
+// Copyright IBM Corp. 2018,2020. All Rights Reserved.
+// Node module: strong-globalize-cli
 // This file is licensed under the Artistic License 2.0.
 // License text available at https://opensource.org/licenses/Artistic-2.0
+
 'use strict';
 
 var gpbHelper = require('./gpb-translate-helper');

--- a/packages/cli/test/test-translate-6.js
+++ b/packages/cli/test/test-translate-6.js
@@ -1,7 +1,8 @@
-// Copyright IBM Corp. 2016. All Rights Reserved.
-// Node module: strong-globalize
+// Copyright IBM Corp. 2018,2020. All Rights Reserved.
+// Node module: strong-globalize-cli
 // This file is licensed under the Artistic License 2.0.
 // License text available at https://opensource.org/licenses/Artistic-2.0
+
 'use strict';
 
 var gpbHelper = require('./gpb-translate-helper');

--- a/packages/cli/test/test-translate-7.js
+++ b/packages/cli/test/test-translate-7.js
@@ -1,7 +1,8 @@
-// Copyright IBM Corp. 2016. All Rights Reserved.
-// Node module: strong-globalize
+// Copyright IBM Corp. 2018,2020. All Rights Reserved.
+// Node module: strong-globalize-cli
 // This file is licensed under the Artistic License 2.0.
 // License text available at https://opensource.org/licenses/Artistic-2.0
+
 'use strict';
 
 var gpbHelper = require('./gpb-translate-helper');

--- a/packages/cli/test/test-translate-8.js
+++ b/packages/cli/test/test-translate-8.js
@@ -1,7 +1,8 @@
-// Copyright IBM Corp. 2016. All Rights Reserved.
-// Node module: strong-globalize
+// Copyright IBM Corp. 2018,2020. All Rights Reserved.
+// Node module: strong-globalize-cli
 // This file is licensed under the Artistic License 2.0.
 // License text available at https://opensource.org/licenses/Artistic-2.0
+
 'use strict';
 
 var gpbHelper = require('./gpb-translate-helper');

--- a/packages/cli/test/test-translate-9.js
+++ b/packages/cli/test/test-translate-9.js
@@ -1,7 +1,8 @@
-// Copyright IBM Corp. 2016. All Rights Reserved.
-// Node module: strong-globalize
+// Copyright IBM Corp. 2018,2020. All Rights Reserved.
+// Node module: strong-globalize-cli
 // This file is licensed under the Artistic License 2.0.
 // License text available at https://opensource.org/licenses/Artistic-2.0
+
 'use strict';
 
 var gpbHelper = require('./gpb-translate-helper');

--- a/packages/cli/test/test-translate.js
+++ b/packages/cli/test/test-translate.js
@@ -1,7 +1,8 @@
-// Copyright IBM Corp. 2016. All Rights Reserved.
-// Node module: strong-globalize
+// Copyright IBM Corp. 2018,2020. All Rights Reserved.
+// Node module: strong-globalize-cli
 // This file is licensed under the Artistic License 2.0.
 // License text available at https://opensource.org/licenses/Artistic-2.0
+
 'use strict';
 
 var SG = require('strong-globalize');

--- a/packages/runtime/benchmark/format.js
+++ b/packages/runtime/benchmark/format.js
@@ -1,3 +1,8 @@
+// Copyright IBM Corp. 2018,2020. All Rights Reserved.
+// Node module: strong-globalize
+// This file is licensed under the Artistic License 2.0.
+// License text available at https://opensource.org/licenses/Artistic-2.0
+
 'use strict';
 
 var f = require('util').format;

--- a/packages/runtime/browser.js
+++ b/packages/runtime/browser.js
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2015,2018. All Rights Reserved.
+// Copyright IBM Corp. 2018,2020. All Rights Reserved.
 // Node module: strong-globalize
 // This file is licensed under the Artistic License 2.0.
 // License text available at https://opensource.org/licenses/Artistic-2.0

--- a/packages/runtime/examples/gmain/index.js
+++ b/packages/runtime/examples/gmain/index.js
@@ -1,7 +1,8 @@
-// Copyright IBM Corp. 2015,2016. All Rights Reserved.
+// Copyright IBM Corp. 2018,2020. All Rights Reserved.
 // Node module: strong-globalize
 // This file is licensed under the Artistic License 2.0.
 // License text available at https://opensource.org/licenses/Artistic-2.0
+
 'use strict';
 
 var SG = require('strong-globalize');

--- a/packages/runtime/examples/gsub/index.js
+++ b/packages/runtime/examples/gsub/index.js
@@ -1,7 +1,8 @@
-// Copyright IBM Corp. 2015,2016. All Rights Reserved.
+// Copyright IBM Corp. 2018,2020. All Rights Reserved.
 // Node module: strong-globalize
 // This file is licensed under the Artistic License 2.0.
 // License text available at https://opensource.org/licenses/Artistic-2.0
+
 'use strict';
 
 var SG = require('strong-globalize');

--- a/packages/runtime/index.js
+++ b/packages/runtime/index.js
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2015,2018. All Rights Reserved.
+// Copyright IBM Corp. 2018,2020. All Rights Reserved.
 // Node module: strong-globalize
 // This file is licensed under the Artistic License 2.0.
 // License text available at https://opensource.org/licenses/Artistic-2.0

--- a/packages/runtime/src/browser.ts
+++ b/packages/runtime/src/browser.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2015,2016. All Rights Reserved.
+// Copyright IBM Corp. 2018,2020. All Rights Reserved.
 // Node module: strong-globalize
 // This file is licensed under the Artistic License 2.0.
 // License text available at https://opensource.org/licenses/Artistic-2.0

--- a/packages/runtime/src/config.ts
+++ b/packages/runtime/src/config.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2015,2018. All Rights Reserved.
+// Copyright IBM Corp. 2018,2020. All Rights Reserved.
 // Node module: strong-globalize
 // This file is licensed under the Artistic License 2.0.
 // License text available at https://opensource.org/licenses/Artistic-2.0

--- a/packages/runtime/src/global.ts
+++ b/packages/runtime/src/global.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2015,2018. All Rights Reserved.
+// Copyright IBM Corp. 2018,2020. All Rights Reserved.
 // Node module: strong-globalize
 // This file is licensed under the Artistic License 2.0.
 // License text available at https://opensource.org/licenses/Artistic-2.0

--- a/packages/runtime/src/globalize.ts
+++ b/packages/runtime/src/globalize.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2015,2016. All Rights Reserved.
+// Copyright IBM Corp. 2018,2020. All Rights Reserved.
 // Node module: strong-globalize
 // This file is licensed under the Artistic License 2.0.
 // License text available at https://opensource.org/licenses/Artistic-2.0

--- a/packages/runtime/src/helper.ts
+++ b/packages/runtime/src/helper.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2015,2016. All Rights Reserved.
+// Copyright IBM Corp. 2018,2020. All Rights Reserved.
 // Node module: strong-globalize
 // This file is licensed under the Artistic License 2.0.
 // License text available at https://opensource.org/licenses/Artistic-2.0

--- a/packages/runtime/src/strong-globalize.ts
+++ b/packages/runtime/src/strong-globalize.ts
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2015,2018. All Rights Reserved.
+// Copyright IBM Corp. 2018,2020. All Rights Reserved.
 // Node module: strong-globalize
 // This file is licensed under the Artistic License 2.0.
 // License text available at https://opensource.org/licenses/Artistic-2.0

--- a/packages/runtime/test/gpb-translate-helper.js
+++ b/packages/runtime/test/gpb-translate-helper.js
@@ -1,7 +1,8 @@
-// Copyright IBM Corp. 2016. All Rights Reserved.
+// Copyright IBM Corp. 2018,2020. All Rights Reserved.
 // Node module: strong-globalize
 // This file is licensed under the Artistic License 2.0.
 // License text available at https://opensource.org/licenses/Artistic-2.0
+
 'use strict';
 
 var gpb = require('g11n-pipeline');

--- a/packages/runtime/test/load-msg-helper.js
+++ b/packages/runtime/test/load-msg-helper.js
@@ -1,7 +1,8 @@
-// Copyright IBM Corp. 2016. All Rights Reserved.
+// Copyright IBM Corp. 2018,2020. All Rights Reserved.
 // Node module: strong-globalize
 // This file is licensed under the Artistic License 2.0.
 // License text available at https://opensource.org/licenses/Artistic-2.0
+
 'use strict';
 
 var SG = require('../');

--- a/packages/runtime/test/node_modules/fifth/index.js
+++ b/packages/runtime/test/node_modules/fifth/index.js
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2016. All Rights Reserved.
+// Copyright IBM Corp. 2018,2020. All Rights Reserved.
 // Node module: strong-globalize
 // This file is licensed under the Artistic License 2.0.
 // License text available at https://opensource.org/licenses/Artistic-2.0

--- a/packages/runtime/test/node_modules/fourth/index.js
+++ b/packages/runtime/test/node_modules/fourth/index.js
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2016. All Rights Reserved.
+// Copyright IBM Corp. 2018,2020. All Rights Reserved.
 // Node module: strong-globalize
 // This file is licensed under the Artistic License 2.0.
 // License text available at https://opensource.org/licenses/Artistic-2.0

--- a/packages/runtime/test/node_modules/secondary/index.js
+++ b/packages/runtime/test/node_modules/secondary/index.js
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2016. All Rights Reserved.
+// Copyright IBM Corp. 2018,2020. All Rights Reserved.
 // Node module: strong-globalize
 // This file is licensed under the Artistic License 2.0.
 // License text available at https://opensource.org/licenses/Artistic-2.0

--- a/packages/runtime/test/node_modules/third/index.js
+++ b/packages/runtime/test/node_modules/third/index.js
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2016. All Rights Reserved.
+// Copyright IBM Corp. 2018,2020. All Rights Reserved.
 // Node module: strong-globalize
 // This file is licensed under the Artistic License 2.0.
 // License text available at https://opensource.org/licenses/Artistic-2.0

--- a/packages/runtime/test/node_modules/third/node_modules/fourth/index.js
+++ b/packages/runtime/test/node_modules/third/node_modules/fourth/index.js
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2016. All Rights Reserved.
+// Copyright IBM Corp. 2018,2020. All Rights Reserved.
 // Node module: strong-globalize
 // This file is licensed under the Artistic License 2.0.
 // License text available at https://opensource.org/licenses/Artistic-2.0

--- a/packages/runtime/test/slt-test-helper.js
+++ b/packages/runtime/test/slt-test-helper.js
@@ -1,7 +1,8 @@
-// Copyright IBM Corp. 2016. All Rights Reserved.
+// Copyright IBM Corp. 2018,2020. All Rights Reserved.
 // Node module: strong-globalize
 // This file is licensed under the Artistic License 2.0.
 // License text available at https://opensource.org/licenses/Artistic-2.0
+
 'use strict';
 
 var async = require('async');

--- a/packages/runtime/test/test-format-json.js
+++ b/packages/runtime/test/test-format-json.js
@@ -1,7 +1,8 @@
-// Copyright IBM Corp. 2016. All Rights Reserved.
+// Copyright IBM Corp. 2018,2020. All Rights Reserved.
 // Node module: strong-globalize
 // This file is licensed under the Artistic License 2.0.
 // License text available at https://opensource.org/licenses/Artistic-2.0
+
 'use strict';
 
 var SG = require('../');

--- a/packages/runtime/test/test-globalize-errors.js
+++ b/packages/runtime/test/test-globalize-errors.js
@@ -1,7 +1,8 @@
-// Copyright IBM Corp. 2016. All Rights Reserved.
+// Copyright IBM Corp. 2018,2020. All Rights Reserved.
 // Node module: strong-globalize
 // This file is licensed under the Artistic License 2.0.
 // License text available at https://opensource.org/licenses/Artistic-2.0
+
 'use strict';
 
 var SG = require('../');

--- a/packages/runtime/test/test-globalize-multiple.js
+++ b/packages/runtime/test/test-globalize-multiple.js
@@ -1,7 +1,8 @@
-// Copyright IBM Corp. 2016. All Rights Reserved.
+// Copyright IBM Corp. 2018,2020. All Rights Reserved.
 // Node module: strong-globalize
 // This file is licensed under the Artistic License 2.0.
 // License text available at https://opensource.org/licenses/Artistic-2.0
+
 'use strict';
 
 var SG = require('../');

--- a/packages/runtime/test/test-globalize-singleton.js
+++ b/packages/runtime/test/test-globalize-singleton.js
@@ -1,7 +1,8 @@
-// Copyright IBM Corp. 2016. All Rights Reserved.
+// Copyright IBM Corp. 2018,2020. All Rights Reserved.
 // Node module: strong-globalize
 // This file is licensed under the Artistic License 2.0.
 // License text available at https://opensource.org/licenses/Artistic-2.0
+
 'use strict';
 
 var g = require('../lib/globalize');

--- a/packages/runtime/test/test-load-msg-forking.js
+++ b/packages/runtime/test/test-load-msg-forking.js
@@ -1,7 +1,8 @@
-// Copyright IBM Corp. 2016. All Rights Reserved.
+// Copyright IBM Corp. 2018,2020. All Rights Reserved.
 // Node module: strong-globalize
 // This file is licensed under the Artistic License 2.0.
 // License text available at https://opensource.org/licenses/Artistic-2.0
+
 'use strict';
 
 var async = require('async');

--- a/packages/runtime/test/test-load-msg-non-forking.js
+++ b/packages/runtime/test/test-load-msg-non-forking.js
@@ -1,7 +1,8 @@
-// Copyright IBM Corp. 2016. All Rights Reserved.
+// Copyright IBM Corp. 2018,2020. All Rights Reserved.
 // Node module: strong-globalize
 // This file is licensed under the Artistic License 2.0.
 // License text available at https://opensource.org/licenses/Artistic-2.0
+
 'use strict';
 
 var async = require('async');

--- a/packages/runtime/test/test-load-msg.js
+++ b/packages/runtime/test/test-load-msg.js
@@ -1,7 +1,8 @@
-// Copyright IBM Corp. 2016. All Rights Reserved.
+// Copyright IBM Corp. 2018,2020. All Rights Reserved.
 // Node module: strong-globalize
 // This file is licensed under the Artistic License 2.0.
 // License text available at https://opensource.org/licenses/Artistic-2.0
+
 'use strict';
 
 var SG = require('../lib/index');

--- a/packages/runtime/test/test-logging-multiple.js
+++ b/packages/runtime/test/test-logging-multiple.js
@@ -1,7 +1,8 @@
-// Copyright IBM Corp. 2016. All Rights Reserved.
+// Copyright IBM Corp. 2018,2020. All Rights Reserved.
 // Node module: strong-globalize
 // This file is licensed under the Artistic License 2.0.
 // License text available at https://opensource.org/licenses/Artistic-2.0
+
 'use strict';
 
 var SG = require('../');

--- a/packages/runtime/test/test-logging-singleton.js
+++ b/packages/runtime/test/test-logging-singleton.js
@@ -1,7 +1,8 @@
-// Copyright IBM Corp. 2016. All Rights Reserved.
+// Copyright IBM Corp. 2018,2020. All Rights Reserved.
 // Node module: strong-globalize
 // This file is licensed under the Artistic License 2.0.
 // License text available at https://opensource.org/licenses/Artistic-2.0
+
 'use strict';
 
 var g = require('../lib/globalize');

--- a/packages/runtime/test/test-misc-format.js
+++ b/packages/runtime/test/test-misc-format.js
@@ -1,7 +1,8 @@
-// Copyright IBM Corp. 2016. All Rights Reserved.
+// Copyright IBM Corp. 2018,2020. All Rights Reserved.
 // Node module: strong-globalize
 // This file is licensed under the Artistic License 2.0.
 // License text available at https://opensource.org/licenses/Artistic-2.0
+
 'use strict';
 
 var SG = require('../');

--- a/packages/runtime/test/test-misc-help.js
+++ b/packages/runtime/test/test-misc-help.js
@@ -1,7 +1,8 @@
-// Copyright IBM Corp. 2016. All Rights Reserved.
+// Copyright IBM Corp. 2018,2020. All Rights Reserved.
 // Node module: strong-globalize
 // This file is licensed under the Artistic License 2.0.
 // License text available at https://opensource.org/licenses/Artistic-2.0
+
 'use strict';
 
 var globalize = require('../lib/globalize');

--- a/packages/runtime/test/test-package.js
+++ b/packages/runtime/test/test-package.js
@@ -1,7 +1,8 @@
-// Copyright IBM Corp. 2015,2016. All Rights Reserved.
+// Copyright IBM Corp. 2018,2020. All Rights Reserved.
 // Node module: strong-globalize
 // This file is licensed under the Artistic License 2.0.
 // License text available at https://opensource.org/licenses/Artistic-2.0
+
 'use strict';
 
 var test = require('tap').test;

--- a/packages/runtime/test/test-scan-object.js
+++ b/packages/runtime/test/test-scan-object.js
@@ -1,7 +1,8 @@
-// Copyright IBM Corp. 2016. All Rights Reserved.
+// Copyright IBM Corp. 2018,2020. All Rights Reserved.
 // Node module: strong-globalize
 // This file is licensed under the Artistic License 2.0.
 // License text available at https://opensource.org/licenses/Artistic-2.0
+
 'use strict';
 
 var helper = require('../lib/helper');

--- a/packages/runtime/test/test-setdir.js
+++ b/packages/runtime/test/test-setdir.js
@@ -1,7 +1,8 @@
-// Copyright IBM Corp. 2016. All Rights Reserved.
+// Copyright IBM Corp. 2018,2020. All Rights Reserved.
 // Node module: strong-globalize
 // This file is licensed under the Artistic License 2.0.
 // License text available at https://opensource.org/licenses/Artistic-2.0
+
 'use strict';
 
 var helper = require('../lib/helper');

--- a/packages/runtime/test/test-sort-msges.js
+++ b/packages/runtime/test/test-sort-msges.js
@@ -1,7 +1,8 @@
-// Copyright IBM Corp. 2016. All Rights Reserved.
+// Copyright IBM Corp. 2018,2020. All Rights Reserved.
 // Node module: strong-globalize
 // This file is licensed under the Artistic License 2.0.
 // License text available at https://opensource.org/licenses/Artistic-2.0
+
 'use strict';
 
 var helper = require('../lib/helper');

--- a/packages/util/app.js
+++ b/packages/util/app.js
@@ -1,7 +1,6 @@
-// Copyright IBM Corp. 2016. All Rights Reserved.
-// Node module: strong-globalize
-// This file is licensed under the Artistic License 2.0.
-// License text available at https://opensource.org/licenses/Artistic-2.0
+// Copyright Tetsuo Seto 2018,2020. All Rights Reserved.
+// Node module: strong-globalize-util
+
 'use strict';
 
 const _ = require('lodash');


### PR DESCRIPTION
Related to: https://github.com/strongloop-internal/scrum-apex/issues/440

Changes are introduced by running `slt copyright` command.
I didn't include the changes in the test/fixtures files. 