### PR TITLE
Account for differences in accept-language header

### DIFF
--- a/packages/runtime/src/helper.ts
+++ b/packages/runtime/src/helper.ts
@@ -865,13 +865,15 @@ export function getLanguageFromRequest(
   appLanguages: string[],
   defaultLanguage: string
 ): string {
-  if (!req || !req.headers) {
+  if (!req || !req.headers || !req.headers['accept-language']) {
     return defaultLanguage;
   }
 
   let languages = req.headers['accept-language'].split(',');
   for (let i = 0; i < languages.length; i++) {
-    languages[i] = getLangAlias(languages[i]);
+    let languageWeighted = languages[i].split(';');
+    languageWeighted[0] = getLangAlias(languageWeighted[0].trim());
+    languages[i] = languageWeighted.join(';');
   }
   const reqLanguage = languages.join(',');
   if (!reqLanguage) {


### PR DESCRIPTION
Hello all, sorry to bring this up again.
**Issue:** https://github.com/strongloop/strong-globalize/issues/157
The changes I made last time fixed the issue for the regional accept-languages. However, it made a regression for headers without the `accept-language` header. While fixing the issue, I also realized that there are weighted http headers. So I wanted to account for that too.

**Purpose of PR:**
The purpose of this PR is to account for the different accept-language headers that are possible during a request. 

**Tests:**
Made new tests to account for the different accept-language.
1. If there is one header, but no accept-language
2. If there is an empty accept-language header
3. If there is a wildcard, `*`, accept-language header
4. If there are multiple, weighted headers.