### PR TITLE
Do case handling for language aliases

### DIFF
--- a/packages/runtime/src/helper.ts
+++ b/packages/runtime/src/helper.ts
@@ -968,10 +968,11 @@ export function removeDoubleCurlyBraces(json: AnyObject) {
  */
 export function getLangAlias(lang: string): string {
   // The {lang: alias} pairs
+  let language = _.toLower(lang) || lang;
   const ALIAS_MAP: {[lang: string]: string} = {
     'zh-cn': 'zh-Hans',
     'zh-tw': 'zh-Hant',
   };
-  if (lang && ALIAS_MAP.hasOwnProperty(lang)) return ALIAS_MAP[lang];
+  if (lang && ALIAS_MAP.hasOwnProperty(language)) return ALIAS_MAP[language];
   return lang;
 }

--- a/packages/runtime/test/test-load-msg.js
+++ b/packages/runtime/test/test-load-msg.js
@@ -114,6 +114,23 @@ test('accept-language header - alias', function (t) {
   t.end();
 });
 
+test('accept-language header - alias, case handling', function (t) {
+  var req = {
+    headers: {
+      // alias to 'zh-Hans'
+      'accept-language': 'zh-CN',
+    },
+  };
+
+  // create a SG instance for language 'zh-Hans' and register it
+  var sg_hans = new SG({language: 'zh-Hans'});
+  SG.sgCache.set('zh-Hans', sg_hans);
+
+  var cachedSg = g.http(req);
+  t.equal(cachedSg.getLanguage(), 'zh-Hans');
+  t.end();
+});
+
 test('multiple, weighted, accept-language header with alias', function (t) {
   var req = {
     headers: {


### PR DESCRIPTION
Chrome has an accept-language header for Chinese languages as zh-TW and zh-CN by default. Other browsers may have something similar.
Thus it is necessary that when there is a need for language aliases, the language code is standardized. The current getLanguageAlias does not handle that case!
