### PR TITLE
Use default language when using accept-language

### DIFF
--- a/packages/runtime/src/helper.ts
+++ b/packages/runtime/src/helper.ts
@@ -880,6 +880,7 @@ export function getLanguageFromRequest(
     return defaultLanguage;
   }
 
+  appLanguages.unshift(defaultLanguage);
   acceptLanguage.languages(appLanguages);
   const bestLanguage = acceptLanguage.get(reqLanguage);
   return bestLanguage || defaultLanguage;

--- a/packages/runtime/test/test-load-msg.js
+++ b/packages/runtime/test/test-load-msg.js
@@ -12,7 +12,7 @@ var test = require('tap').test;
 
 SG.SetRootDir(__dirname);
 SG.SetDefaultLanguage();
-SG.SetAppLanguages(['en', 'zh-Hans', 'zh-Hant']);
+SG.SetAppLanguages(['de', 'en', 'zh-Hans', 'zh-Hant']);
 
 var g = new SG();
 
@@ -147,5 +147,17 @@ test('multiple, weighted, accept-language header with alias', function (t) {
 
   var message = g.http(req).f('log');
   t.equal(message, '原木');
+  t.end();
+});
+
+test('language not in list should default to en', function (t) {
+  var req = {
+    headers: {
+      'accept-language': 'id',
+    },
+  };
+
+  var cachedSg = g.http(req);
+  t.equal(cachedSg.getLanguage(), 'en');
   t.end();
 });


### PR DESCRIPTION
Currently the http() function does not choose a default language correctly if the request language is not supported.

This is because the accept-language module uses the first language in the `appLanguages` array as the default language. In order for g.http() to choose the default language correctly, the default language can be added to the front of the language list.